### PR TITLE
feat(user): crear entidad y repository con metodos básicos de JPA.

### DIFF
--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/config/JpaAuditingConfig.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/config/JpaAuditingConfig.java
@@ -1,4 +1,18 @@
 package com.javadiseno.sanosysalvos.user.config;
 
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/**
+ * SY-1 Activa JPA Auditing
+ *
+ * Sin esta anotacion, los campos 'created_at' y 'updated_at' de la tabla 'user'
+ * quedan null al persistir.
+ *
+ * @author Christián Mesa
+ */
+@Configuration // Indicar a Spring que en esa clase se define la configuración de la apliación.
+@EnableJpaAuditing // Permite activar la auditoría de entidades en segundo plano.
 public class JpaAuditingConfig {
+    // No hay codigo, la anotación se encarga de proporcionar lo necesario para realizar el trabajo.
 }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/config/JpaAuditingConfig.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/config/JpaAuditingConfig.java
@@ -1,0 +1,4 @@
+package com.javadiseno.sanosysalvos.user.config;
+
+public class JpaAuditingConfig {
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/Role.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/Role.java
@@ -1,4 +1,18 @@
 package com.javadiseno.sanosysalvos.user.model;
 
-public class Role {
+/**
+ * SY-1/SY-8 - Roles de usuario en la plataforma.
+ *
+ * OWNER: ciudadano que reporta mascotas perdidas o encontradas.
+ * VOLUNTEER: participa en operativos de busqueda y ve zonas asignadas.
+ * ADMIN: gestiona la plataforma (cambiar roles de usuario, dashboards).
+ *
+ * Se le asigna por defecto a cada usuario que se registre el rol de 'OWNER'.
+ *
+ * @author Christián Mesa
+ */
+public enum Role {
+    OWNER,
+    VOLUNTEER,
+    ADMIN
 }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/Role.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/Role.java
@@ -1,0 +1,4 @@
+package com.javadiseno.sanosysalvos.user.model;
+
+public class Role {
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/User.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/User.java
@@ -1,4 +1,103 @@
 package com.javadiseno.sanosysalvos.user.model;
 
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * SY-1 - Crear Entidad User
+ *
+ * Esta clase representa a cualquier usuario registrado en la plataforma.
+ * El rol determina qué puede hacer, por ejemplo: DUENO puede reportar mascotas,
+ * un VOLUNTARIO puede ver zonas asignadas, un ADMIN administra la plataforma.
+ *
+ * Estructura:
+ *
+ * - ID: Identificador de tipo UUID generado por java antes de persistir. De esta forma no se depende de la Base de Datos.
+ * - Email: Unico a nivel de Base de Datos.
+ * - Password: Nunca se almacena de manera clara. Solo se guarda formateada en hash por BCryptPasswordEncoder
+ *   en la capa 'service'.
+ * - Auditoría minima: Se usara createdAt y updateAt mediante JPA Auditing para monitoreo.
+ *
+ * @author Christián Mesa
+ */
+
+@EntityListeners(AuditingEntityListener.class) // Activa @CreatedDate y @LastModifiedDate
+@Entity // Mapear la clase a una tabla de BD.
+@Table(name = "user") // Definir nombre de la tabla.
+@Getter // Genera metodos getter para cada campo de la clase, permitiendo obtener información del objeto.
+@Setter // Genera metodos setter para cada campo de la clase, permitiendo cambiar o establecer informacion del objeto fuera de la clase.
+@NoArgsConstructor // Genera un constructor sin argumentos para la clase User.
+@AllArgsConstructor // Genera un constructor con argumentos para cada campo de la clase User.
 public class User {
+
+    // -- Identificador ---------------------
+
+    @Id //Marca el campo 'id' como clave primaria de la tabla 'user'.
+    private UUID id;
+
+    /**
+     * Se asigna el UUID antes de persistir para no depender de la BD.
+     */
+    @PrePersist // Marca el metodo 'assignId' para que se ejecute automáticamente antes que se haga un INSERT por primera vez en la BD.
+    public void assignId(){
+        if(this.id == null){
+            this.id = UUID.randomUUID();
+        }
+    }
+
+    // -- Datos de Acceso ---------------------
+
+    @Column(name = "email", nullable = false, unique = true, length = 100) // Configurar propiedades de la columna 'email' (no nulo y único).
+    private String email;
+
+    /**
+     * Hash BCrypt. Nunca se expone en DTOs de respuesta.
+     */
+    @Column(name = "hash_password", nullable = false) // Configurar propiedades de la columna 'hash_password' (no nulo).
+    private String hashPassword;
+
+    // -- Datos Personales ---------------------
+
+    @Column(name = "name", nullable = false, length = 50) // Configurar propiedades de la columna 'name' (no nulo, longitud).
+    private String name; // Nombres del usuario
+
+    @Column(name = "last_name", nullable = false, length = 50) // Configurar propiedades de la columna 'last_name' (no nulo, longitud).
+    private String lastName; // Apellidos del usuario
+
+    @Column(name = "phone", length = 20) // Configurar propiedades de la columna 'phone' (no nulo).
+    private String phone; // Teléfono del usuario
+
+    // -- Rol ---------------------
+
+    /**
+     * Rol de usuario en la plataforma.
+     *
+     * Reglas de negocio (SY-8)
+     *  - El rol asignado por defecto siempre sera 'OWNER'
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20) // Configurar propiedades de la columna 'last_name' (no nulo, longitud).
+    private Role role;
+
+    // -- Auditoria ---------------------
+
+    /**
+     * Fecha de Creación: la asigna JPA Auditing al primer persist.
+     */
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false) // Configurar propiedades de la columna 'created_at' (no nulo y no actualizable).
+    private LocalDateTime createdAt;
+
+    /**
+     * Fecha de Última Modificación: se actualiza en cada update.
+     */
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/User.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/User.java
@@ -1,0 +1,4 @@
+package com.javadiseno.sanosysalvos.user.model;
+
+public class User {
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/repository/UserRepository.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/repository/UserRepository.java
@@ -1,0 +1,4 @@
+package com.javadiseno.sanosysalvos.user.repository;
+
+public interface UserRepository {
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/repository/UserRepository.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/repository/UserRepository.java
@@ -1,4 +1,19 @@
 package com.javadiseno.sanosysalvos.user.repository;
 
-public interface UserRepository {
+import com.javadiseno.sanosysalvos.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+/**
+ * SY-1 Repositorio de User
+ *
+ * Contiene los métodos para interactuar con la Base de Datos de usuarios mediante operaciones CRUD.
+ * Los metodos básicos como save, findById o delete vienen de JpaRepository.
+ *
+ * @author Christián Mesa
+ */
+@Repository // Marcar como componente de la capa de persistencia.
+public interface UserRepository extends JpaRepository<User, UUID> {
 }


### PR DESCRIPTION
# SY-1 Crear entidad del usuario

## ¿Por qué?
La entidad del usuario es una pieza fundamental que define los campos que tendrá a la hora del futuro registro y autenticación. 
Aspectos importantes como el rol permitirán que se establezca un orden en los privilegios, asegurando el principio del minimo privilegio.
- Hash de contraseña con **BCryptPasswordEncoder**
- Uso de JPA Auditing para `created_at` y `updated_at`
- UserRepository con métodos CRUD básicos mediante JpaRepository