### PR TITLE
SY-20 feat(report): microservicio msvc-report (API REST, JPA/H2, Postman

### DIFF
--- a/msvc-report/postman/msvc-report.postman_collection.json
+++ b/msvc-report/postman/msvc-report.postman_collection.json
@@ -1,0 +1,256 @@
+{
+  "info": {
+    "_postman_id": "b2c3d4e5-msvc-report",
+    "name": "msvc-report (Sanos y Salvos)",
+    "description": "Todas las peticiones HTTP expuestas por msvc-report.\n\n- Puerto por defecto: 8082 (`application.properties`).\n- Cabecera `X-User-Id` (UUID): usada donde el código la documenta como temporal hasta JWT.\n- Sustituye las variables `reportId`, `petId`, `userId`, etc. por UUIDs reales de tu entorno.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "http://localhost:8082" },
+    { "key": "reportId", "value": "00000000-0000-0000-0000-000000000001" },
+    { "key": "petId", "value": "00000000-0000-0000-0000-000000000002" },
+    { "key": "userId", "value": "00000000-0000-0000-0000-000000000003" },
+    { "key": "sightingId", "value": "00000000-0000-0000-0000-000000000004" },
+    { "key": "mediaId", "value": "00000000-0000-0000-0000-000000000005" }
+  ],
+  "item": [
+    {
+      "name": "Reports (CRUD principal)",
+      "item": [
+        {
+          "name": "GET Listar reportes (paginado)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports?page=0&size=20&sort=reportedAt,desc",
+            "description": "Lista paginada (`Pageable`). Ajusta `page`, `size`, `sort`."
+          }
+        },
+        {
+          "name": "POST Crear reporte",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-User-Id", "value": "{{userId}}", "description": "Opcional si `reporterUserId` va en el body." }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tipo\": \"PERDIDO\",\n  \"titulo\": \"Se perdió mi mascota\",\n  \"descripcion\": \"Detalles del reporte\",\n  \"latitud\": -34.6,\n  \"longitud\": -58.4,\n  \"ubicacionTexto\": \"CABA\",\n  \"fechaReporte\": \"2026-04-10T15:00:00Z\",\n  \"petId\": \"{{petId}}\",\n  \"reporterUserId\": \"{{userId}}\"\n}"
+            },
+            "url": "{{baseUrl}}/api/v1/reports",
+            "description": "`tipo`: PERDIDO|ENCONTRADO|AVISTAMIENTO (o LOST|FOUND|SIGHTING). `petId` obligatorio con la lógica actual."
+          }
+        },
+        {
+          "name": "GET Reporte por id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}"
+          }
+        },
+        {
+          "name": "PATCH Actualizar reporte (parcial)",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"titulo\": \"Título actualizado\",\n  \"descripcion\": \"Nueva descripción\",\n  \"latitud\": -34.61,\n  \"longitud\": -58.41,\n  \"ubicacionTexto\": \"Nueva zona\",\n  \"fechaReporte\": \"2026-04-10T16:00:00Z\"\n}"
+            },
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}"
+          }
+        },
+        {
+          "name": "POST Resolver reporte (cerrar con nota)",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"motivo\": \"ENCONTRADO\",\n  \"nota\": \"La mascota volvió a casa\"\n}"
+            },
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/resolve",
+            "description": "Body opcional; si no envías nada, usa objeto vacío en servidor."
+          }
+        },
+        {
+          "name": "POST Resolver reporte (sin body)",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/resolve"
+          }
+        },
+        {
+          "name": "PATCH Cerrar reporte",
+          "request": {
+            "method": "PATCH",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/close"
+          }
+        },
+        {
+          "name": "DELETE Eliminar reporte",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pets → Reports",
+      "item": [
+        {
+          "name": "GET Reportes por mascota (paginado)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/pets/{{petId}}/reports?page=0&size=20"
+          }
+        },
+        {
+          "name": "GET Todos los reportes de la mascota (lista)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/pets/{{petId}}/reports/all",
+            "description": "Orden por `reportedAt` descendente en servicio."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Users → Reports",
+      "item": [
+        {
+          "name": "GET Mis reportes (me)",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "X-User-Id", "value": "{{userId}}" }],
+            "url": "{{baseUrl}}/api/v1/users/me/reports",
+            "description": "Requiere cabecera `X-User-Id` hasta integrar JWT."
+          }
+        },
+        {
+          "name": "GET Reportes por usuario",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/users/{{userId}}/reports"
+          }
+        },
+        {
+          "name": "GET Un reporte de un usuario",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/users/{{userId}}/reports/{{reportId}}",
+            "description": "404 si el reporte no pertenece a ese usuario."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Reports → Sightings",
+      "item": [
+        {
+          "name": "GET Listar avistamientos del reporte",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/sightings"
+          }
+        },
+        {
+          "name": "GET Un avistamiento",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/sightings/{{sightingId}}"
+          }
+        },
+        {
+          "name": "POST Crear avistamiento",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"spottedAt\": \"2026-04-10T18:00:00Z\",\n  \"notes\": \"Visto cerca del parque\"\n}"
+            },
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/sightings",
+            "description": "El `report` lo asigna el servidor; no hace falta enviarlo."
+          }
+        },
+        {
+          "name": "DELETE Eliminar avistamiento",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/sightings/{{sightingId}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Reports → Media",
+      "item": [
+        {
+          "name": "GET Listar medios del reporte",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/media"
+          }
+        },
+        {
+          "name": "GET Un medio",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/media/{{mediaId}}"
+          }
+        },
+        {
+          "name": "POST Añadir medio (URL)",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"url\": \"https://ejemplo.com/foto.jpg\",\n  \"sortOrder\": 0\n}"
+            },
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/media",
+            "description": "`url` obligatoria; `sortOrder` opcional."
+          }
+        },
+        {
+          "name": "DELETE Eliminar medio",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": "{{baseUrl}}/api/v1/reports/{{reportId}}/media/{{mediaId}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Herramientas (dev)",
+      "item": [
+        {
+          "name": "GET Consola H2 (navegador)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/h2-console",
+            "description": "Solo con perfil `dev` y `spring.h2.console.enabled=true`. Abre en el navegador."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/config/SecurityConfig.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.javadiseno.sanosysalvos.report.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Permite llamar a la API sin JWT mientras se integra el gateway / usuario.
+ * Ajustar a {@code authenticated()} cuando se defina las reglas por rol.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/PetReportController.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/PetReportController.java
@@ -1,0 +1,36 @@
+package com.javadiseno.sanosysalvos.report.controllers;
+
+import com.javadiseno.sanosysalvos.report.models.ReportModel;
+import com.javadiseno.sanosysalvos.report.services.ReportService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * reportes asociados a una mascota 
+ */
+@RestController
+@RequestMapping("/api/v1/pets/{petId}/reports")
+@RequiredArgsConstructor
+public class PetReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping 
+    public Page<ReportModel> page(@PathVariable UUID petId, @PageableDefault(size = 20) Pageable pageable) {
+        return reportService.findByPetId(petId, pageable); 
+    }
+
+    /** lista completa sin paginas osea los mas recientes primero*/
+    @GetMapping("/all")
+    public List<ReportModel> listAll(@PathVariable UUID petId) {
+        return reportService.findByPetIdOrderByReportedAtDesc(petId);
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/ReportController.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/ReportController.java
@@ -1,0 +1,83 @@
+package com.javadiseno.sanosysalvos.report.controllers;
+
+import com.javadiseno.sanosysalvos.report.dtos.requests.CreateReportRequest;
+import com.javadiseno.sanosysalvos.report.dtos.requests.PatchReportRequest;
+import com.javadiseno.sanosysalvos.report.dtos.requests.ResolveReportRequest;
+import com.javadiseno.sanosysalvos.report.exceptions.ResourceNotFoundException;
+import com.javadiseno.sanosysalvos.report.mapping.ReportApiMapper;
+import com.javadiseno.sanosysalvos.report.models.ReportModel;
+import com.javadiseno.sanosysalvos.report.services.ReportService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ *  controlador principal de reportes (get, post, patch, delete) para pet,sighting y media 
+ */
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping
+    public Page<ReportModel> list(@PageableDefault(size = 20) Pageable pageable) {
+        return reportService.findAll(pageable);
+    }
+
+    //TEMPORAL: permite obtener el usuario por el body o el header SIN JWT autenticado
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ReportModel create(
+            @RequestBody CreateReportRequest body,
+            @RequestHeader(value = "X-User-Id", required = false) UUID userIdFromHeader) {
+        UUID reporter = body.getReporterUserId() != null ? body.getReporterUserId() : userIdFromHeader;
+        ReportModel entity = ReportApiMapper.toNewEntity(body, reporter);
+        return reportService.save(entity);
+    }
+
+    @GetMapping("/{reportId}")
+    public ReportModel getById(@PathVariable UUID reportId) {
+        return reportService
+                .findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException("Report no encontrado: " + reportId));
+    }
+
+    @PatchMapping("/{reportId}")
+    public ReportModel patch(@PathVariable UUID reportId, @RequestBody PatchReportRequest body) {
+        return reportService.updateReport(reportId, body);
+    }
+
+    //resolver un reporte osea confirmar que la mascota fue encontrada
+    @PostMapping("/{reportId}/resolve")
+    public ReportModel resolve(
+            @PathVariable UUID reportId, @RequestBody(required = false) ResolveReportRequest body) {
+        return reportService.resolveReport(reportId, body != null ? body : new ResolveReportRequest());
+    }
+
+    //cerrar un reporte da igual si fue resuelto o no
+    @PatchMapping("/{reportId}/close")
+    public ReportModel close(@PathVariable UUID reportId) {
+        return reportService.closeReport(reportId);
+    }
+
+    @DeleteMapping("/{reportId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID reportId) {
+        reportService.deleteById(reportId);
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/ReportMediaController.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/ReportMediaController.java
@@ -1,0 +1,71 @@
+package com.javadiseno.sanosysalvos.report.controllers;
+
+import com.javadiseno.sanosysalvos.report.exceptions.ResourceNotFoundException;
+import com.javadiseno.sanosysalvos.report.models.ReportMedia;
+import com.javadiseno.sanosysalvos.report.models.ReportModel;
+import com.javadiseno.sanosysalvos.report.services.MediaService;
+import com.javadiseno.sanosysalvos.report.services.ReportService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reports/{reportId}/media")
+@RequiredArgsConstructor
+public class ReportMediaController {
+
+    private final ReportService reportService;
+    private final MediaService mediaService;
+
+    @GetMapping
+    public List<ReportMedia> list(@PathVariable UUID reportId) {
+        ensureReportExists(reportId);
+        return mediaService.findByReportIdOrderBySortOrderAscCreatedAtAsc(reportId);
+    }
+
+    @GetMapping("/{mediaId}")
+    public ReportMedia getOne(@PathVariable UUID reportId, @PathVariable UUID mediaId) {
+        ensureReportExists(reportId);
+        ReportMedia m = mediaService
+                .findById(mediaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Medio no encontrado: " + mediaId));
+        if (!reportId.equals(m.getReport().getId())) {
+            throw new ResourceNotFoundException("El medio no pertenece a este reporte");
+        }
+        return m;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ReportMedia create(@PathVariable UUID reportId, @RequestBody ReportMedia body) {
+        ReportModel report = reportService
+                .findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException("Report no encontrado: " + reportId));
+        body.setReport(report);
+        return mediaService.save(body);
+    }
+
+
+    @DeleteMapping("/{mediaId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID reportId, @PathVariable UUID mediaId) {
+        getOne(reportId, mediaId);
+        mediaService.deleteById(mediaId);
+    }
+
+    //verificar que el reporte existe para no crear un medio sin reporte
+    private void ensureReportExists(UUID reportId) {
+        if (reportService.findById(reportId).isEmpty()) {
+            throw new ResourceNotFoundException("Report no encontrado: " + reportId);
+        }
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/ReportSightingController.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/ReportSightingController.java
@@ -1,0 +1,72 @@
+package com.javadiseno.sanosysalvos.report.controllers;
+
+import com.javadiseno.sanosysalvos.report.exceptions.ResourceNotFoundException;
+import com.javadiseno.sanosysalvos.report.models.ReportModel;
+import com.javadiseno.sanosysalvos.report.models.ReportSighting;
+import com.javadiseno.sanosysalvos.report.services.ReportService;
+import com.javadiseno.sanosysalvos.report.services.SightingService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * avistamientos asociados a un reporte
+ */
+@RestController
+@RequestMapping("/api/v1/reports/{reportId}/sightings")
+@RequiredArgsConstructor
+public class ReportSightingController {
+
+    private final ReportService reportService;
+    private final SightingService sightingService;
+
+    @GetMapping
+    public List<ReportSighting> list(@PathVariable UUID reportId) {
+        ensureReportExists(reportId);
+        return sightingService.findByReportIdOrderBySpottedAtDesc(reportId);
+    }
+
+    @GetMapping("/{sightingId}") 
+    public ReportSighting getOne(@PathVariable UUID reportId, @PathVariable UUID sightingId) {
+        ensureReportExists(reportId);
+        ReportSighting s = sightingService
+                .findById(sightingId)
+                .orElseThrow(() -> new ResourceNotFoundException("Avistamiento no encontrado: " + sightingId));
+        if (!reportId.equals(s.getReport().getId())) {
+            throw new ResourceNotFoundException("Avistamiento no pertenece a este reporte");
+        }
+        return s;
+    }
+
+    @PostMapping 
+    @ResponseStatus(HttpStatus.CREATED)
+    public ReportSighting create(@PathVariable UUID reportId, @RequestBody ReportSighting body) {
+        ReportModel report = reportService
+                .findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException("Report no encontrado: " + reportId));
+        body.setReport(report);
+        return sightingService.save(body);
+    }
+
+    @DeleteMapping("/{sightingId}") 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID reportId, @PathVariable UUID sightingId) {
+        getOne(reportId, sightingId);
+        sightingService.deleteById(sightingId);
+    }
+
+    private void ensureReportExists(UUID reportId) {
+        if (reportService.findById(reportId).isEmpty()) {
+            throw new ResourceNotFoundException("Report no encontrado: " + reportId);
+        }
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/UserReportController.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/controllers/UserReportController.java
@@ -1,0 +1,54 @@
+package com.javadiseno.sanosysalvos.report.controllers;
+
+import com.javadiseno.sanosysalvos.report.exceptions.ReportException;
+import com.javadiseno.sanosysalvos.report.exceptions.ResourceNotFoundException;
+import com.javadiseno.sanosysalvos.report.models.ReportModel;
+import com.javadiseno.sanosysalvos.report.services.ReportService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * reportes asociados a un usuario
+ */
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserReportController {
+
+    private final ReportService reportService;
+
+    //el me es el usuario que esta autenticado TODO _: hay q cambiarlo por el jwt
+    @GetMapping("/me/reports")
+    public List<ReportModel> myReports(
+            @RequestHeader(value = "X-User-Id", required = false) UUID userId) {
+        if (userId == null) {
+            throw new ReportException("Cabecera X-User-Id requerida hasta integrar JWT");
+        }
+        return reportService.findByReporterUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    //lista de reportes de un usuario
+    @GetMapping("/{userId}/reports")
+    public List<ReportModel> listByUser(@PathVariable UUID userId) {
+        return reportService.findByReporterUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    //obtener un reporte de un usuario
+    @GetMapping("/{userId}/reports/{reportId}")
+    public ReportModel getByUserAndReport(
+            @PathVariable UUID userId, @PathVariable UUID reportId) {
+        ReportModel r = reportService
+                .findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException("Report no encontrado: " + reportId));
+        if (!userId.equals(r.getReporterUserId())) {
+            throw new ResourceNotFoundException("Report no encontrado para este usuario");
+        }
+        return r;
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/dtos/ErrorDTO.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/dtos/ErrorDTO.java
@@ -1,0 +1,32 @@
+package com.javadiseno.sanosysalvos.report.dtos;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Respuesta JSON para errores del microservicio de reportes.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorDTO {
+
+    private int status;
+    private String message;
+    private String details;
+    private LocalDateTime timestamp;
+    private String path;
+    /** errores por campo validacion */
+    private Map<String, String> errors;
+
+    public ErrorDTO(int status, String message, String details, String path) {
+        this.status = status;
+        this.message = message;
+        this.details = details;
+        this.path = path;
+        this.timestamp = LocalDateTime.now();
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/dtos/requests/CreateReportRequest.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/dtos/requests/CreateReportRequest.java
@@ -1,0 +1,53 @@
+package com.javadiseno.sanosysalvos.report.dtos.requests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.Data;
+
+/**
+ * Contrato cercano a la wiki ClickUp (APIS DETALLADAS). {@code pet} sin orquestación Pet Service aún.
+ */
+@Data
+public class CreateReportRequest {
+
+    /** PERDIDO | ENCONTRADO | AVISTAMIENTO o LOST | FOUND | SIGHTING */
+    private String tipo;
+
+    private String titulo;
+
+    private String descripcion;
+
+    private BigDecimal latitud;
+
+    private BigDecimal longitud;
+
+    @JsonProperty("ubicacionTexto")
+    private String ubicacionTexto;
+
+    @JsonProperty("fechaReporte")
+    private Instant fechaReporte;
+
+    @JsonProperty("petId")
+    private UUID petId;
+
+    /** Si viene sin petId, la wiki prevé alta de mascota; aquí no está orquestado. */
+    private PetMinimoDto pet;
+
+    @JsonProperty("reporterUserId")
+    private UUID reporterUserId;
+
+    @JsonProperty("mediaIds")
+    private List<UUID> mediaIds;
+
+    @Data
+    public static class PetMinimoDto {
+        private String nombre;
+        private String especie;
+        private String raza;
+        private String color;
+        private String tamano;
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/dtos/requests/PatchReportRequest.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/dtos/requests/PatchReportRequest.java
@@ -1,0 +1,25 @@
+package com.javadiseno.sanosysalvos.report.dtos.requests;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.Data;
+
+/** Actualización parcial de metadatos (wiki: PATCH /reports/{id}). */
+@Data
+public class PatchReportRequest {
+
+    private String titulo;
+
+    private String descripcion;
+
+    private BigDecimal latitud;
+
+    private BigDecimal longitud;
+
+    @JsonProperty("ubicacionTexto")
+    private String ubicacionTexto;
+
+    @JsonProperty("fechaReporte")
+    private Instant fechaReporte;
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/dtos/requests/ResolveReportRequest.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/dtos/requests/ResolveReportRequest.java
@@ -1,0 +1,12 @@
+package com.javadiseno.sanosysalvos.report.dtos.requests;
+
+import lombok.Data;
+
+/** Cuerpo opcional para POST .../resolve (wiki SY-25). */
+@Data
+public class ResolveReportRequest {
+
+    private String motivo;
+
+    private String nota;
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/exceptions/GlobalExceptionHandler.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,134 @@
+package com.javadiseno.sanosysalvos.report.exceptions;
+
+import com.javadiseno.sanosysalvos.report.dtos.ErrorDTO;
+import feign.FeignException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Manejo de errores HTTP para msvc-report .
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    private final Environment environment;
+
+    public GlobalExceptionHandler(Environment environment) {
+        this.environment = environment;
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorDTO> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        Map<String, String> errorMap = new HashMap<>();
+        for (FieldError fe : ex.getBindingResult().getFieldErrors()) {
+            errorMap.put(fe.getField(), fe.getDefaultMessage());
+        }
+
+        ErrorDTO body = new ErrorDTO();
+        body.setStatus(HttpStatus.BAD_REQUEST.value());
+        body.setMessage("Errores de validación");
+        body.setDetails("Se encontraron " + errorMap.size() + " error(es)");
+        body.setTimestamp(LocalDateTime.now());
+        body.setPath(request.getRequestURI());
+        body.setErrors(errorMap);
+
+        log.warn("Validación en {}: {}", request.getRequestURI(), errorMap);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorDTO> handleNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
+        ErrorDTO body = new ErrorDTO(
+                HttpStatus.NOT_FOUND.value(),
+                "Recurso no encontrado",
+                ex.getMessage(),
+                request.getRequestURI());
+        log.warn("404 en {}: {}", request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<ErrorDTO> handleFeign(FeignException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.BAD_GATEWAY;
+        String message = "Error al comunicar con otro microservicio";
+        String details = ex.getMessage();
+
+        if (ex.status() == 404) {
+            status = HttpStatus.NOT_FOUND;
+            message = "Recurso no encontrado en servicio externo";
+        } else if (ex.status() >= 400 && ex.status() < 500) {
+            status = HttpStatus.resolve(ex.status()) != null ? HttpStatus.valueOf(ex.status()) : status;
+            message = "Error en solicitud a servicio externo";
+        }
+
+        ErrorDTO body = new ErrorDTO(status.value(), message, details, request.getRequestURI());
+        log.error("Feign en {} status={}: {}", request.getRequestURI(), ex.status(), details);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(ReportException.class)
+    public ResponseEntity<ErrorDTO> handleReport(ReportException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        String lower = ex.getMessage() != null ? ex.getMessage().toLowerCase() : "";
+
+        if (lower.contains("no encontrado") || lower.contains("no existe")) {
+            status = HttpStatus.NOT_FOUND;
+        } else if (lower.contains("ya existe")
+                || lower.contains("duplicado")
+                || lower.contains("conflicto")
+                || lower.contains("ya está cerrado")) {
+            status = HttpStatus.CONFLICT;
+        } else if (lower.contains("no autorizado") || lower.contains("acceso denegado")) {
+            status = HttpStatus.FORBIDDEN;
+        }
+
+        ErrorDTO body = new ErrorDTO(
+                status.value(),
+                "Error en operación de reporte",
+                ex.getMessage(),
+                request.getRequestURI());
+
+        log.warn("ReportException en {}: {}", request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorDTO> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
+        ErrorDTO body = new ErrorDTO(
+                HttpStatus.BAD_REQUEST.value(),
+                "Solicitud inválida",
+                ex.getMessage(),
+                request.getRequestURI());
+        log.warn("IllegalArgument en {}: {}", request.getRequestURI(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorDTO> handleGeneric(Exception ex, HttpServletRequest request) {
+        String details = "Ocurrió un error inesperado.";
+        if (environment.acceptsProfiles(Profiles.of("dev"))) {
+            details = ex.getClass().getSimpleName() + ": " + (ex.getMessage() != null ? ex.getMessage() : "");
+        }
+        ErrorDTO body = new ErrorDTO(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "Error interno del servidor",
+                details,
+                request.getRequestURI());
+        log.error("Error no manejado en {}: {}", request.getRequestURI(), ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/exceptions/ReportException.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/exceptions/ReportException.java
@@ -1,0 +1,20 @@
+package com.javadiseno.sanosysalvos.report.exceptions;
+
+/**
+ * Errores de dominio del Report Service (reglas de negocio, datos inconsistentes).
+ * Traducidos a HTTP por {@code GlobalExceptionHandler}.
+ */
+public class ReportException extends RuntimeException {
+
+    public ReportException(String message) {
+        super(message);
+    }
+
+    public ReportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ReportException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/exceptions/ResourceNotFoundException.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,15 @@
+package com.javadiseno.sanosysalvos.report.exceptions;
+
+/**
+ * Recurso solicitado no existe (reporte, avistamiento, medio, etc.).
+ */
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/mapping/ReportApiMapper.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/mapping/ReportApiMapper.java
@@ -1,0 +1,73 @@
+package com.javadiseno.sanosysalvos.report.mapping;
+
+import com.javadiseno.sanosysalvos.report.dtos.requests.CreateReportRequest;
+import com.javadiseno.sanosysalvos.report.dtos.requests.PatchReportRequest;
+import com.javadiseno.sanosysalvos.report.exceptions.ReportException;
+import com.javadiseno.sanosysalvos.report.models.ReportModel;
+import com.javadiseno.sanosysalvos.report.models.ReportModel.ReportType;
+import java.util.Locale;
+import java.util.UUID;
+
+public final class ReportApiMapper {
+
+    private ReportApiMapper() {}
+
+    public static ReportModel toNewEntity(CreateReportRequest req, UUID reporterUserIdEfectivo) {
+        if (req.getPet() != null && req.getPetId() == null) {
+            throw new ReportException(
+                    "Alta de mascota embebida (objeto pet) pendiente de orquestación con Pet Service; envíe petId.");
+        }
+        if (req.getPetId() == null) {
+            throw new ReportException("petId es obligatorio hasta integrar creación automática de mascota.");
+        }
+        if (reporterUserIdEfectivo == null) {
+            throw new ReportException("reporterUserId es obligatorio (body o cabecera X-User-Id).");
+        }
+        ReportType type = parseTipo(req.getTipo());
+        ReportModel m = new ReportModel();
+        m.setPetId(req.getPetId());
+        m.setReporterUserId(reporterUserIdEfectivo);
+        m.setType(type);
+        m.setTitle(req.getTitulo());
+        m.setDescription(req.getDescripcion());
+        m.setLatitude(req.getLatitud());
+        m.setLongitude(req.getLongitud());
+        m.setLocationDescription(req.getUbicacionTexto());
+        m.setReportedAt(req.getFechaReporte() != null ? req.getFechaReporte() : java.time.Instant.now());
+        return m;
+    }
+
+    public static void applyPatch(ReportModel target, PatchReportRequest p) {
+        if (p.getTitulo() != null) {
+            target.setTitle(p.getTitulo());
+        }
+        if (p.getDescripcion() != null) {
+            target.setDescription(p.getDescripcion());
+        }
+        if (p.getLatitud() != null) {
+            target.setLatitude(p.getLatitud());
+        }
+        if (p.getLongitud() != null) {
+            target.setLongitude(p.getLongitud());
+        }
+        if (p.getUbicacionTexto() != null) {
+            target.setLocationDescription(p.getUbicacionTexto());
+        }
+        if (p.getFechaReporte() != null) {
+            target.setReportedAt(p.getFechaReporte());
+        }
+    }
+
+    static ReportType parseTipo(String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw new ReportException("tipo es obligatorio");
+        }
+        String t = raw.trim().toUpperCase(Locale.ROOT);
+        return switch (t) {
+            case "PERDIDO", "LOST" -> ReportType.LOST;
+            case "ENCONTRADO", "FOUND" -> ReportType.FOUND;
+            case "AVISTAMIENTO", "SIGHTING" -> ReportType.SIGHTING;
+            default -> throw new ReportException("tipo inválido: " + raw);
+        };
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/models/ReportMedia.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/models/ReportMedia.java
@@ -1,0 +1,49 @@
+package com.javadiseno.sanosysalvos.report.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Enlace a un recurso multimedia (URL) asociado a un reporte.
+ */
+@Entity
+@Table(name = "report_media")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReportMedia {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @JsonIgnore //para evitar json muy grandes y evitar recursividad
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) //no lo carga de inmediato en la bd sino que lo carga cuando se necesita
+    @JoinColumn(name = "report_id", nullable = false)
+    private ReportModel report;//muchos comentarios pertenecen a un reporte
+
+    @Column(name = "url", nullable = false, length = 2048)
+    private String url;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();//evita olvidar la fecha de creación manualmente
+        }
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/models/ReportModel.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/models/ReportModel.java
@@ -1,0 +1,110 @@
+package com.javadiseno.sanosysalvos.report.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Reporte de mascota (perdido / encontrado / avistamiento).
+ */
+@Entity
+@Table(name = "reports")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReportModel {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "pet_id", nullable = false)
+    private UUID petId;
+
+    @Column(name = "reporter_user_id", nullable = false)
+    private UUID reporterUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private ReportType type;
+
+    @Column(length = 500)
+    private String title;
+
+    @Column(columnDefinition = "text")
+    private String description;
+
+    private BigDecimal latitude;
+
+    private BigDecimal longitude;
+
+    @Column(name = "location_description", length = 2000)
+    private String locationDescription;
+
+    @Column(name = "reported_at", nullable = false)
+    private Instant reportedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private ReportStatus status;
+
+    @Column(name = "resolved_at")
+    private Instant resolvedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ReportSighting> sightings = new ArrayList<>();
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ReportMedia> mediaLinks = new ArrayList<>();
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+        if (reportedAt == null) {
+            reportedAt = createdAt;
+        }
+        if (status == null) {
+            status = ReportStatus.ACTIVE;
+        }
+    }
+
+    public enum ReportType {
+        LOST,
+        FOUND,
+        SIGHTING
+    }
+
+    public enum ReportStatus {
+        ACTIVE,
+        CLOSED
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/models/ReportSighting.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/models/ReportSighting.java
@@ -1,0 +1,52 @@
+package com.javadiseno.sanosysalvos.report.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+  avistamiento asociado a un reporte (ej: un posible avistamiento de la mascota).
+ */
+@Entity
+@Table(name = "report_sightings")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReportSighting {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "report_id", nullable = false)
+    private ReportModel report;
+
+    @Column(name = "spotted_at", nullable = false)
+    private Instant spottedAt;
+
+    @Column(name = "notes", columnDefinition = "text")
+    private String notes;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+        if (spottedAt == null) {
+            spottedAt = createdAt;
+        }
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/repositories/MediaRepository.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/repositories/MediaRepository.java
@@ -1,0 +1,22 @@
+package com.javadiseno.sanosysalvos.report.repositories;
+
+import com.javadiseno.sanosysalvos.report.models.ReportMedia;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+  Poner texto luego
+ */
+@Repository
+public interface MediaRepository extends JpaRepository<ReportMedia, UUID> {
+
+    List<ReportMedia> findByReport_Id(UUID reportId);
+
+    List<ReportMedia> findByReport_IdOrderBySortOrderAscCreatedAtAsc(UUID reportId);
+
+    long countByReport_Id(UUID reportId);
+
+    void deleteByReport_Id(UUID reportId);
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/repositories/ReportRepository.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/repositories/ReportRepository.java
@@ -1,0 +1,40 @@
+package com.javadiseno.sanosysalvos.report.repositories;
+
+import com.javadiseno.sanosysalvos.report.models.ReportModel;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+  reportes de mascotas perdidas, encontradas o vistas.
+ */
+@Repository
+public interface ReportRepository extends JpaRepository<ReportModel, UUID> {
+
+    /** Columna BD {@code pet_id} → propiedad {@code petId}. */
+    List<ReportModel> findByPetId(UUID petId);
+
+    Page<ReportModel> findByPetId(UUID petId, Pageable pageable);
+
+    List<ReportModel> findByPetIdOrderByReportedAtDesc(UUID petId);
+
+    /** Columna BD {@code reporter_user_id} → propiedad {@code reporterUserId}. */
+    List<ReportModel> findByReporterUserIdOrderByCreatedAtDesc(UUID reporterUserId);
+
+    @EntityGraph(attributePaths = "sightings")
+    @Query("SELECT r FROM ReportModel r WHERE r.id = :id")
+    Optional<ReportModel> findWithSightingsById(@Param("id") UUID id);
+
+    @EntityGraph(attributePaths = "mediaLinks")
+    @Query("SELECT r FROM ReportModel r WHERE r.id = :id")
+    Optional<ReportModel> findWithMediaById(@Param("id") UUID id);
+
+    boolean existsByIdAndReporterUserId(UUID id, UUID reporterUserId);
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/repositories/SightingRepository.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/repositories/SightingRepository.java
@@ -1,0 +1,25 @@
+package com.javadiseno.sanosysalvos.report.repositories;
+
+import com.javadiseno.sanosysalvos.report.models.ReportSighting;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+  avistamientos asociados a un reporte (id del reporte)
+ */
+@Repository
+public interface SightingRepository extends JpaRepository<ReportSighting, UUID> {
+
+    List<ReportSighting> findByReport_Id(UUID reportId);
+
+    List<ReportSighting> findByReport_Id(UUID reportId, Sort sort);
+
+    List<ReportSighting> findByReport_IdOrderBySpottedAtDesc(UUID reportId);
+
+    long countByReport_Id(UUID reportId);
+
+    void deleteByReport_Id(UUID reportId);
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/MediaService.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/MediaService.java
@@ -1,0 +1,23 @@
+package com.javadiseno.sanosysalvos.report.services;
+
+import com.javadiseno.sanosysalvos.report.models.ReportMedia;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MediaService {
+
+    Optional<ReportMedia> findById(UUID id);
+
+    List<ReportMedia> findByReportId(UUID reportId);
+
+    List<ReportMedia> findByReportIdOrderBySortOrderAscCreatedAtAsc(UUID reportId);
+
+    long countByReportId(UUID reportId);
+
+    void deleteByReportId(UUID reportId);
+
+    ReportMedia save(ReportMedia media);
+
+    void deleteById(UUID id);
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/MediaServiceImpl.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/MediaServiceImpl.java
@@ -1,0 +1,73 @@
+package com.javadiseno.sanosysalvos.report.services;
+
+import com.javadiseno.sanosysalvos.report.exceptions.ReportException;
+import com.javadiseno.sanosysalvos.report.exceptions.ResourceNotFoundException;
+import com.javadiseno.sanosysalvos.report.models.ReportMedia;
+import com.javadiseno.sanosysalvos.report.repositories.MediaRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ medios asociados a un reporte (url) alojado en s3 en el microservicio msvc-media
+*/
+@Service
+@RequiredArgsConstructor
+public class MediaServiceImpl implements MediaService {
+
+    private final MediaRepository mediaRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ReportMedia> findById(UUID id) {
+        return mediaRepository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReportMedia> findByReportId(UUID reportId) {
+        return mediaRepository.findByReport_Id(reportId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReportMedia> findByReportIdOrderBySortOrderAscCreatedAtAsc(UUID reportId) {
+        return mediaRepository.findByReport_IdOrderBySortOrderAscCreatedAtAsc(reportId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countByReportId(UUID reportId) {
+        return mediaRepository.countByReport_Id(reportId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteByReportId(UUID reportId) {
+        mediaRepository.deleteByReport_Id(reportId);
+    }
+
+    @Override
+    @Transactional
+    public ReportMedia save(ReportMedia media) {
+        if (media.getReport() == null) {
+            throw new ReportException("El medio debe tener un report asociado");
+        }
+        if (media.getUrl() == null || media.getUrl().isBlank()) {
+            throw new ReportException("url es obligatoria");
+        }
+        return mediaRepository.save(media);
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(UUID id) {
+        if (!mediaRepository.existsById(id)) {
+            throw new ResourceNotFoundException("Medio no encontrado: " + id);
+        }
+        mediaRepository.deleteById(id);
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/ReportService.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/ReportService.java
@@ -1,0 +1,43 @@
+package com.javadiseno.sanosysalvos.report.services;
+
+import com.javadiseno.sanosysalvos.report.dtos.requests.PatchReportRequest;
+import com.javadiseno.sanosysalvos.report.dtos.requests.ResolveReportRequest;
+import com.javadiseno.sanosysalvos.report.models.ReportModel;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReportService {
+
+    Page<ReportModel> findAll(Pageable pageable);
+
+    Optional<ReportModel> findById(UUID id);
+
+    List<ReportModel> findByPetId(UUID petId);
+
+    Page<ReportModel> findByPetId(UUID petId, Pageable pageable);
+
+    List<ReportModel> findByPetIdOrderByReportedAtDesc(UUID petId);
+
+    List<ReportModel> findByReporterUserIdOrderByCreatedAtDesc(UUID reporterUserId);
+
+    Optional<ReportModel> findWithSightingsById(UUID id);
+
+    Optional<ReportModel> findWithMediaById(UUID id);
+
+    boolean existsByIdAndReporterUserId(UUID reportId, UUID reporterUserId);
+
+    ReportModel save(ReportModel report);
+
+    void deleteById(UUID id);
+
+    /** Marca el reporte como cerrado y fija {@code resolved_at} */
+    ReportModel closeReport(UUID reportId);
+
+    ReportModel updateReport(UUID reportId, PatchReportRequest patch);
+
+    /** Cierra el reporte; opcionalmente anexa motivo/nota (wiki POST .../resolve). */
+    ReportModel resolveReport(UUID reportId, ResolveReportRequest request);
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/ReportServiceImpl.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/ReportServiceImpl.java
@@ -1,0 +1,155 @@
+package com.javadiseno.sanosysalvos.report.services;
+
+import com.javadiseno.sanosysalvos.report.dtos.requests.PatchReportRequest;
+import com.javadiseno.sanosysalvos.report.dtos.requests.ResolveReportRequest;
+import com.javadiseno.sanosysalvos.report.exceptions.ReportException;
+import com.javadiseno.sanosysalvos.report.exceptions.ResourceNotFoundException;
+import com.javadiseno.sanosysalvos.report.mapping.ReportApiMapper;
+import com.javadiseno.sanosysalvos.report.models.ReportModel;
+import com.javadiseno.sanosysalvos.report.models.ReportModel.ReportStatus;
+import com.javadiseno.sanosysalvos.report.repositories.ReportRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ esta logica de negocio tiene 
+ los enlaces a mascota y reportante, y tipo de reporte
+ 
+ */
+@Service
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService {
+
+    private final ReportRepository reportRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ReportModel> findAll(Pageable pageable) {
+        return reportRepository.findAll(pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ReportModel> findById(UUID id) {
+        return reportRepository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReportModel> findByPetId(UUID petId) {
+        return reportRepository.findByPetId(petId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ReportModel> findByPetId(UUID petId, Pageable pageable) {
+        return reportRepository.findByPetId(petId, pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReportModel> findByPetIdOrderByReportedAtDesc(UUID petId) {
+        return reportRepository.findByPetIdOrderByReportedAtDesc(petId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReportModel> findByReporterUserIdOrderByCreatedAtDesc(UUID reporterUserId) {
+        return reportRepository.findByReporterUserIdOrderByCreatedAtDesc(reporterUserId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ReportModel> findWithSightingsById(UUID id) {
+        return reportRepository.findWithSightingsById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ReportModel> findWithMediaById(UUID id) {
+        return reportRepository.findWithMediaById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsByIdAndReporterUserId(UUID reportId, UUID reporterUserId) {
+        return reportRepository.existsByIdAndReporterUserId(reportId, reporterUserId);
+    }
+
+    @Override
+    @Transactional
+    public ReportModel save(ReportModel report) {
+        validateMandatoryFields(report);
+        if (report.getReportedAt() == null) {
+            report.setReportedAt(Instant.now());
+        }
+        if (report.getStatus() == null) {
+            report.setStatus(ReportStatus.ACTIVE);
+        }
+        return reportRepository.save(report);
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(UUID id) {
+        if (!reportRepository.existsById(id)) {
+            throw new ResourceNotFoundException("Report no encontrado: " + id);
+        }
+        reportRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public ReportModel closeReport(UUID reportId) {
+        return resolveReport(reportId, new ResolveReportRequest());
+    }
+
+    @Override
+    @Transactional
+    public ReportModel updateReport(UUID reportId, PatchReportRequest patch) {
+        ReportModel report = reportRepository
+                .findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException("Report no encontrado: " + reportId));
+        ReportApiMapper.applyPatch(report, patch);
+        return reportRepository.save(report);
+    }
+
+    @Override
+    @Transactional
+    public ReportModel resolveReport(UUID reportId, ResolveReportRequest request) {
+        ReportModel report = reportRepository
+                .findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException("Report no encontrado: " + reportId));
+        if (report.getStatus() == ReportStatus.CLOSED) {
+            throw new ReportException("Conflicto: el reporte ya está cerrado");
+        }
+        report.setStatus(ReportStatus.CLOSED);
+        report.setResolvedAt(Instant.now());
+        if (request != null && request.getNota() != null && !request.getNota().isBlank()) {
+            String tag = request.getMotivo() != null ? "[" + request.getMotivo() + "] " : "[Cierre] ";
+            String prev = report.getDescription() != null ? report.getDescription() + "\n" : "";
+            report.setDescription(prev + tag + request.getNota());
+        }
+        return reportRepository.save(report);
+    }
+
+    /**(SY-20): enlaces a mascota y reportante, y tipo de reporte. */
+    private static void validateMandatoryFields(ReportModel report) {
+        if (report.getPetId() == null) {
+            throw new ReportException("petId es obligatorio");
+        }
+        if (report.getReporterUserId() == null) {
+            throw new ReportException("reporterUserId es obligatorio");
+        }
+        if (report.getType() == null) {
+            throw new ReportException("type es obligatorio");
+        }
+    }
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/SightingService.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/SightingService.java
@@ -1,0 +1,26 @@
+package com.javadiseno.sanosysalvos.report.services;
+
+import com.javadiseno.sanosysalvos.report.models.ReportSighting;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Sort;
+
+public interface SightingService {
+
+    Optional<ReportSighting> findById(UUID id);
+
+    List<ReportSighting> findByReportId(UUID reportId);
+
+    List<ReportSighting> findByReportId(UUID reportId, Sort sort);
+
+    List<ReportSighting> findByReportIdOrderBySpottedAtDesc(UUID reportId);
+
+    long countByReportId(UUID reportId);
+
+    void deleteByReportId(UUID reportId);
+
+    ReportSighting save(ReportSighting sighting);
+
+    void deleteById(UUID id);
+}

--- a/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/SightingServiceImpl.java
+++ b/msvc-report/src/main/java/com/javadiseno/sanosysalvos/report/services/SightingServiceImpl.java
@@ -1,0 +1,77 @@
+package com.javadiseno.sanosysalvos.report.services;
+
+import com.javadiseno.sanosysalvos.report.exceptions.ReportException;
+import com.javadiseno.sanosysalvos.report.exceptions.ResourceNotFoundException;
+import com.javadiseno.sanosysalvos.report.models.ReportSighting;
+import com.javadiseno.sanosysalvos.report.repositories.SightingRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Avistamientos (SY-26): deben pertenecer a un reporte.
+ */
+@Service
+@RequiredArgsConstructor
+public class SightingServiceImpl implements SightingService {
+
+    private final SightingRepository sightingRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ReportSighting> findById(UUID id) {
+        return sightingRepository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReportSighting> findByReportId(UUID reportId) {
+        return sightingRepository.findByReport_Id(reportId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReportSighting> findByReportId(UUID reportId, Sort sort) {
+        return sightingRepository.findByReport_Id(reportId, sort);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReportSighting> findByReportIdOrderBySpottedAtDesc(UUID reportId) {
+        return sightingRepository.findByReport_IdOrderBySpottedAtDesc(reportId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countByReportId(UUID reportId) {
+        return sightingRepository.countByReport_Id(reportId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteByReportId(UUID reportId) {
+        sightingRepository.deleteByReport_Id(reportId);
+    }
+
+    @Override
+    @Transactional
+    public ReportSighting save(ReportSighting sighting) {
+        if (sighting.getReport() == null) {
+            throw new ReportException("El avistamiento debe tener un report asociado");
+        }
+        return sightingRepository.save(sighting);
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(UUID id) {
+        if (!sightingRepository.existsById(id)) {
+            throw new ResourceNotFoundException("Avistamiento no encontrado: " + id);
+        }
+        sightingRepository.deleteById(id);
+    }
+}

--- a/msvc-report/src/main/resources/application-dev.properties
+++ b/msvc-report/src/main/resources/application-dev.properties
@@ -1,25 +1,26 @@
 
-# ADVERTENCIA: ESTA BASE DE DATOS H2 SERA TEMPORAL PARA HACER PRUEBAS RAPIDAS.
-# CUANDO SE IMPLEMENTE LA SUBRED PRIVADA CON RDS POSTGRESQL EN AWS SE USARA POSTGREQL.
+# H2 PARA PRUEBAS RAPIDAS 
+# podriamos usar docker para probar en local 
 
-# Especifica la ubicación exacta de la BD (H2, en memoria ram de la pc)
-spring.datasource.url=jdbc:h2:mem:sanosdb
-# Schema
-spring.jpa.properties.hibernate.default_schema=reports_schema
-# Que Driver usar para hablar con H2
+# url de la bd (DB_CLOSE_DELAY evita que la BD en memoria se cierre entre operaciones)
+spring.datasource.url=jdbc:h2:mem:sanosdb;DB_CLOSE_DELAY=-1
+# Sin esquema dedicado en H2: default_schema + H2 suele provocar errores SQL (tablas no visibles / nombres).
+# Para Postgres en prod podrÃ¡s volver a fijar el schema si lo necesitas.
+# spring.jpa.properties.hibernate.default_schema=reports_schema
+spring.jpa.properties.hibernate.hbm2ddl.create_namespaces=true
+# driver de la bd
 spring.datasource.driverClassName=org.h2.Driver
 # Define las credenciales para autenticarse en la BD.
 spring.datasource.username=admin
 spring.datasource.password=sanos123
 
-# Le dice a Hibernate que hable el "Dialecto" de H2
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-# Crea o actualiza las Tablas de la BD al arrancar la App
+# estaba el update y el create 
 spring.jpa.hibernate.ddl-auto=update
-# Mostrar consultas SQL que la aplicación ejecuta
+# mostrar consultas SQL que la aplicacion ejecuta
 spring.jpa.show-sql=true
 
-# Activar interfaz web para ver las tablas y hacer consultas SQL desde el navegador.
+# Activa la interfaz web para ver las tablas y hacer consultas SQL desde el gugul
 spring.h2.console.enabled=true
-# Dirección de la interfaz.
+# ruta de la interfaz
 spring.h2.console.path=/h2-console

--- a/msvc-report/src/main/resources/application.properties
+++ b/msvc-report/src/main/resources/application.properties
@@ -2,3 +2,6 @@ spring.application.name=msvc-report
 server.port=8082
 
 spring.profiles.active=dev
+
+# Spring Boot 4 / Spring Data 4: el modo por defecto (direct) suele romper la serialización JSON de Page con Jackson.
+spring.data.web.pageable.serialization-mode=via-dto


### PR DESCRIPTION

- API REST bajo `/api/v1`: reportes, filtros por mascota/usuario, avistamientos y medios (URLs).
- JPA + H2 en perfil `dev`; modelo `ReportModel` y repositorios.
- Seguridad abierta temporal (`permitAll`) hasta gateway/JWT.
- Colección Postman en `msvc-report/postman/`.
- Serialización estable de `Page` (`spring.data.web.pageable.serialization-mode=via-dto`).
Refs: SY-20