### PR TITLE
SY-3 feat(user): login del usuario

### DIFF
--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/controller/UserController.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/controller/UserController.java
@@ -1,13 +1,15 @@
 package com.javadiseno.sanosysalvos.user.controller;
 
-import com.javadiseno.sanosysalvos.user.dto.RegisterRequestDTO;
-import com.javadiseno.sanosysalvos.user.dto.UserResponseDTO;
+import com.javadiseno.sanosysalvos.user.dto.*;
 import com.javadiseno.sanosysalvos.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * SY-2 | SY-3 Endpoints de autenticación
+ */
 @RestController
 @RequestMapping("api/v1/auth")
 @RequiredArgsConstructor
@@ -15,6 +17,7 @@ public class UserController {
 
     private final UserService userService;
 
+    // SY-2
     @PostMapping("/register")
     public ResponseEntity<UserResponseDTO> register(@Valid @RequestBody RegisterRequestDTO registerRequestDTO){
         UserResponseDTO response = userService.register(registerRequestDTO);
@@ -22,4 +25,12 @@ public class UserController {
                 .status(HttpStatus.CREATED)
                 .body(response);
     };
+
+    // SY-3
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO loginRequestDTO){
+        LoginResponseDTO response = userService.login(loginRequestDTO);
+        return ResponseEntity
+                .ok(response);
+    }
 }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/dto/LoginRequestDTO.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/dto/LoginRequestDTO.java
@@ -1,0 +1,20 @@
+package com.javadiseno.sanosysalvos.user.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+/**
+ * SY-3 DTO de entrada para login.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDTO {
+
+    @NotBlank(message = "El email es obligatorio")
+    @Email(message = "El email no tiene un formato válido")
+    private String email;
+
+    @NotBlank(message = "La contraseña es obligatoria")
+    private String password;
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/dto/LoginResponseDTO.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/dto/LoginResponseDTO.java
@@ -1,0 +1,22 @@
+package com.javadiseno.sanosysalvos.user.dto;
+
+import com.javadiseno.sanosysalvos.user.model.Role;
+import lombok.*;
+
+import java.util.UUID;
+
+/**
+ * SY-3 DTO de respuesta de login.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoginResponseDTO {
+    private String token;
+    private String tokenType;
+    private UUID userId;
+    private String name;
+    private String email;
+    private Role role;
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/exception/GlobalExceptionHandler.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/exception/GlobalExceptionHandler.java
@@ -15,17 +15,6 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler{
 
-        @ExceptionHandler(EmailAlreadyExistsException.class)
-    public ResponseEntity<ErrorResponse> handleEmailAlreadyExists(EmailAlreadyExistsException ex) {
-      return ResponseEntity
-                          .status(HttpStatus.CONFLICT)
-                          .body(new ErrorResponse(
-                      HttpStatus.CONFLICT.value(),
-                      ex.getMessage(),
-                      LocalDateTime.now()
-              ));
-    }
-
     @ExceptionHandler(PasswordMismatchException.class)
     public ResponseEntity<ValidationErrorsResponse> handlePasswordMismatch(PasswordMismatchException ex){
         Map<String, String> errors = new HashMap<>();
@@ -57,6 +46,28 @@ public class GlobalExceptionHandler{
                         HttpStatus.BAD_REQUEST.value(),
                         "Error de validación en los datos enviados",
                         errors,
+                        LocalDateTime.now()
+                ));
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCredentials(InvalidCredentialsException ex){
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse(
+                        HttpStatus.UNAUTHORIZED.value(),
+                        ex.getMessage(),
+                        LocalDateTime.now()
+                ));
+    }
+
+    @ExceptionHandler(EmailAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleEmailAlreadyExists(EmailAlreadyExistsException ex) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(
+                        HttpStatus.CONFLICT.value(),
+                        ex.getMessage(),
                         LocalDateTime.now()
                 ));
     }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/exception/InvalidCredentialsException.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/exception/InvalidCredentialsException.java
@@ -1,0 +1,11 @@
+package com.javadiseno.sanosysalvos.user.exception;
+
+/**
+ * SY-3 Excepción de credenciales incorrectas en Login
+ */
+public class InvalidCredentialsException extends RuntimeException {
+
+    public InvalidCredentialsException() {
+        super("Credenciales inválidas");
+    }
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/repository/UserRepository.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/repository/UserRepository.java
@@ -4,10 +4,13 @@ import com.javadiseno.sanosysalvos.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
 }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/security/SecurityConfig.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/security/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.javadiseno.sanosysalvos.user.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // 1. Desactivamos CSRF porque Postman no envía el token CSRF por defecto
+                .csrf(csrf -> csrf.disable())
+
+                // 2. Permitimos frames para que la consola de H2 se vea (usa frames)
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+
+                // 3. Autorizamos acceso libre a todo por ahora
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/h2-console/**").permitAll() // Consola H2 libre
+                        .anyRequest().permitAll()                      // Endpoints de registro libres
+                );
+
+        return http.build();
+    }
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserService.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserService.java
@@ -1,9 +1,10 @@
 package com.javadiseno.sanosysalvos.user.service;
 
-import com.javadiseno.sanosysalvos.user.dto.RegisterRequestDTO;
-import com.javadiseno.sanosysalvos.user.dto.UserResponseDTO;
+import com.javadiseno.sanosysalvos.user.dto.*;
 
 public interface UserService {
 
     UserResponseDTO register(RegisterRequestDTO registerRequestDTO);
+
+    LoginResponseDTO login(LoginRequestDTO loginRequestDTO);
 }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserServiceImpl.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserServiceImpl.java
@@ -1,18 +1,18 @@
 package com.javadiseno.sanosysalvos.user.service;
 
-import com.javadiseno.sanosysalvos.user.dto.RegisterRequestDTO;
-import com.javadiseno.sanosysalvos.user.dto.UserMapper;
-import com.javadiseno.sanosysalvos.user.dto.UserResponseDTO;
-import com.javadiseno.sanosysalvos.user.exception.EmailAlreadyExistsException;
-import com.javadiseno.sanosysalvos.user.exception.PasswordMismatchException;
+import com.javadiseno.sanosysalvos.user.dto.*;
+import com.javadiseno.sanosysalvos.user.exception.*;
 import com.javadiseno.sanosysalvos.user.model.Role;
 import com.javadiseno.sanosysalvos.user.model.User;
 import com.javadiseno.sanosysalvos.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * SY-2 | SY-3 Implementación de UserService
+ */
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService{
@@ -21,6 +21,7 @@ public class UserServiceImpl implements UserService{
     private final PasswordEncoder passwordEncoder;
     private final UserMapper userMapper;
 
+    //SY-2
     @Override
     @Transactional
     public UserResponseDTO register(RegisterRequestDTO registerRequestDTO) {
@@ -42,5 +43,27 @@ public class UserServiceImpl implements UserService{
         User savedUser = userRepository.save(user);
 
         return userMapper.toResponseDTO(savedUser);
+    }
+
+    //SY-3
+    @Override
+    @Transactional(readOnly = true)
+    public LoginResponseDTO login(LoginRequestDTO loginRequestDTO) {
+
+        User user = userRepository.findByEmail(loginRequestDTO.getEmail())
+                .orElseThrow(InvalidCredentialsException::new);
+
+        if (!passwordEncoder.matches(loginRequestDTO.getPassword(), user.getHashPassword())){
+            throw new InvalidCredentialsException();
+        }
+
+        return LoginResponseDTO.builder()
+                .token("Futuro Token")
+                .tokenType("Bearer")
+                .userId(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .build();
     }
 }


### PR DESCRIPTION
# SY-3 Login de Usuario

## ¿Qué hace este cambio?
- Implementa el flujo de Login, validando credenciales y retornando el DTO correspondiente

## Cambios principales
- Implementa DTOs correspondientes a la entrada y salida de Login
- Agrega Exception de credenciales invalidas que retorna un `401 Unauthorized`
- Agrega el metodo `login` en el servicio de User que retorna el DTO de salida
- Expuesto el endpoint `POST /login` en el controller de User

## ¿Cómo probarlo?
- Iniciar el microservicio de User
- Registrar un usuario
- En Postman, realizar una petición POST a `http://localhost:8081/api/v1/auth/login`
- Enviar un JSON en el Body con `email` y `password`
- Verificar que el servicio retorne el estado `200 OK`