### PR TITLE
SY-4 feat(user): generar JWT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 # JWT_SECRET=cambiar-por-clave-larga-y-aleatoria
 # JWT_EXPIRATION_MS=86400000
 
+# --- TEMPORAL: BD H2 ---
+# DB_USERNAME=admin
+# DB_PASSWORD=change-me-local
+
 # --- Bases de datos (un bloque por servicio cuando existan) ---
 # AUTH_DB_URL=jdbc:postgresql://localhost:5432/auth
 # AUTH_DB_USER=auth

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/dto/LoginResponseDTO.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/dto/LoginResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.*;
 import java.util.UUID;
 
 /**
- * SY-3 DTO de respuesta de login.
+ * SY-3 | SY-4 DTO de respuesta de login.
  */
 @Data
 @AllArgsConstructor

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/JwtService.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/JwtService.java
@@ -1,0 +1,4 @@
+package com.javadiseno.sanosysalvos.user.service;
+
+public interface JwtService {
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/JwtService.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/JwtService.java
@@ -1,4 +1,15 @@
 package com.javadiseno.sanosysalvos.user.service;
 
+import com.javadiseno.sanosysalvos.user.model.User;
+
+/**
+ * SY-4 Contrato para generación y validación del JWT.
+ */
 public interface JwtService {
+
+    String generateToken(User user);
+
+    String extractEmail(String token);
+
+    boolean isTokenValid(String token);
 }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/JwtServiceImpl.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/JwtServiceImpl.java
@@ -1,0 +1,4 @@
+package com.javadiseno.sanosysalvos.user.service;
+
+public class JwtServiceImpl {
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/JwtServiceImpl.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/JwtServiceImpl.java
@@ -1,4 +1,69 @@
 package com.javadiseno.sanosysalvos.user.service;
 
-public class JwtServiceImpl {
+import com.javadiseno.sanosysalvos.user.model.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * SY-4 Implementación de JwtService.
+ */
+@Slf4j
+@Service
+public class JwtServiceImpl implements JwtService {
+
+    private final SecretKey secretKey;
+    private final Long expirationMs;
+
+    public JwtServiceImpl(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.expiration-ms}") Long expirationMs) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    @Override
+    public String generateToken(User user){
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(user.getId().toString())
+                .claim("email", user.getEmail())
+                .claim("role", user.getRole())
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    @Override
+    public String extractEmail(String token) {
+        return parseClaims(token).get("email", String.class);
+    }
+
+    @Override
+    public boolean isTokenValid(String token){
+        try{
+            Claims claims = parseClaims(token);
+            return claims.getExpiration().after(new Date());
+        }catch (JwtException | IllegalArgumentException e){
+            log.warn("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
 }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserServiceImpl.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserServiceImpl.java
@@ -20,6 +20,7 @@ public class UserServiceImpl implements UserService{
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final UserMapper userMapper;
+    private final JwtService jwtService;
 
     //SY-2
     @Override
@@ -45,7 +46,7 @@ public class UserServiceImpl implements UserService{
         return userMapper.toResponseDTO(savedUser);
     }
 
-    //SY-3
+    //SY-3 | SY-4
     @Override
     @Transactional(readOnly = true)
     public LoginResponseDTO login(LoginRequestDTO loginRequestDTO) {
@@ -57,8 +58,10 @@ public class UserServiceImpl implements UserService{
             throw new InvalidCredentialsException();
         }
 
+        String token = jwtService.generateToken(user);
+
         return LoginResponseDTO.builder()
-                .token("Futuro Token")
+                .token(token)
                 .tokenType("Bearer")
                 .userId(user.getId())
                 .name(user.getName())

--- a/msvc-user/src/main/resources/application-dev.properties
+++ b/msvc-user/src/main/resources/application-dev.properties
@@ -9,8 +9,8 @@ spring.jpa.properties.hibernate.default_schema=users_schema
 # Que Driver usar para hablar con H2
 spring.datasource.driverClassName=org.h2.Driver
 # Define las credenciales para autenticarse en la BD.
-spring.datasource.username=admin
-spring.datasource.password=sanos123
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 
 # Le dice a Hibernate que hable el "Dialecto" de H2
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
@@ -23,3 +23,6 @@ spring.jpa.show-sql=true
 spring.h2.console.enabled=true
 # Dirección de la interfaz.
 spring.h2.console.path=/h2-console
+
+jwt.secret=${JWT_SECRET}
+jwt.expiration-ms=${JWT_EXPIRATION_MS:86400000}


### PR DESCRIPTION
# SY-4 Generar JWT

## ¿Qué hace este cambio?
- Implementa la generación de JWT firmado con la clave secreta y tiempo de expiración

## Cambios principales
- Implementa el servicio de JWT que contiene métodos importantes para su generación, validación y extracción de datos
- La llave secreta no se versiona en GitHub (se configura en las variables de entorno local)
- Se aplico su generación en el Login del usuario

## ¿Cómo probarlo?
- Iniciar el microservicio de User
- Registrar un usuario
- En Postman, realizar una petición POST a `http://localhost:8081/api/v1/auth/login`
- Enviar un JSON en el Body con `email` y `password`
- Verificar que el token retorne correctamente