### PR TITLE
SY-8 feat(user): roles

### DIFF
--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/config/DataInitializerConfig.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/config/DataInitializerConfig.java
@@ -1,0 +1,49 @@
+package com.javadiseno.sanosysalvos.user.config;
+
+import com.javadiseno.sanosysalvos.user.model.Role;
+import com.javadiseno.sanosysalvos.user.model.User;
+import com.javadiseno.sanosysalvos.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * TEMPORAL - ETAPA DEV:
+ * Creación de usuario Admin al iniciar la aplicación
+ */
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class DataInitializerConfig {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Bean
+    CommandLineRunner initAdmin() {
+        return args -> {
+            if (userRepository.findUserByEmail("admin@test.com").isEmpty()){
+                User admin = User.builder()
+                        .id(UUID.randomUUID())
+                        .email("admin@test.com")
+                        .hashPassword(passwordEncoder.encode("admin123"))
+                        .name("Admin")
+                        .lastName("Salvos")
+                        .phone("+56912345678")
+                        .role(Role.ADMIN)
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .build();
+                userRepository.save(admin);
+                log.info("TEMPORAL - Usuario con rol {} y email {} creado y persistido con exito en H2", admin.getRole() ,admin.getEmail());
+            }
+        };
+    }
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/controller/UserController.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/controller/UserController.java
@@ -1,14 +1,18 @@
 package com.javadiseno.sanosysalvos.user.controller;
 
+import com.javadiseno.sanosysalvos.user.dto.ChangeRoleRequestDTO;
 import com.javadiseno.sanosysalvos.user.dto.UpdateProfileRequestDTO;
 import com.javadiseno.sanosysalvos.user.dto.UserResponseDTO;
 import com.javadiseno.sanosysalvos.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 /**
  * SY-6  Endpoints de User
@@ -37,6 +41,18 @@ public class UserController {
             ){
 
         UserResponseDTO profile = userService.updateUserProfile(userDetails.getUsername(), updateProfileRequestDTO);
+        return ResponseEntity
+                .ok(profile);
+    }
+
+    @PatchMapping("/{id}/role")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<UserResponseDTO> updateMyProfile(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID id,
+            @Valid @RequestBody ChangeRoleRequestDTO changeRoleRequestDTO
+    ){
+        UserResponseDTO profile = userService.changeUserRole(userDetails.getUsername(), id, changeRoleRequestDTO);
         return ResponseEntity
                 .ok(profile);
     }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/dto/ChangeRoleRequestDTO.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/dto/ChangeRoleRequestDTO.java
@@ -1,0 +1,14 @@
+package com.javadiseno.sanosysalvos.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChangeRoleRequestDTO {
+
+    @NotNull(message = "El rol es obligatorio")
+    private String role;
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/exception/GlobalExceptionHandler.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.javadiseno.sanosysalvos.user.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,6 +27,17 @@ public class GlobalExceptionHandler{
                         HttpStatus.BAD_REQUEST.value(),
                         "Error de coincidencia",
                         errors,
+                        LocalDateTime.now()
+                ));
+    }
+
+    @ExceptionHandler(SelfRoleChangeException.class)
+    public ResponseEntity<ErrorResponse> handleSelfRoleChange(SelfRoleChangeException ex){
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(
+                        HttpStatus.BAD_REQUEST.value(),
+                        ex.getMessage(),
                         LocalDateTime.now()
                 ));
     }
@@ -61,6 +73,17 @@ public class GlobalExceptionHandler{
                 ));
     }
 
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex){
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse(
+                        HttpStatus.FORBIDDEN.value(),
+                        ex.getMessage(),
+                        LocalDateTime.now()
+                ));
+    }
+
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleUserNotFound (UserNotFoundException ex){
         return ResponseEntity
@@ -84,7 +107,7 @@ public class GlobalExceptionHandler{
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+    public ResponseEntity<ErrorResponse> handleException() {
       return ResponseEntity
               .status(HttpStatus.INTERNAL_SERVER_ERROR)
               .body(new ErrorResponse(

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/exception/SelfRoleChangeException.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/exception/SelfRoleChangeException.java
@@ -1,0 +1,8 @@
+package com.javadiseno.sanosysalvos.user.exception;
+
+public class SelfRoleChangeException extends RuntimeException{
+
+    public SelfRoleChangeException(){
+        super("No puedes cambiar tu propio rol");
+    }
+}

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/User.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/User.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class User {
 
     @Id

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserService.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserService.java
@@ -2,6 +2,8 @@ package com.javadiseno.sanosysalvos.user.service;
 
 import com.javadiseno.sanosysalvos.user.dto.*;
 
+import java.util.UUID;
+
 public interface UserService {
 
     UserResponseDTO register(RegisterRequestDTO registerRequestDTO);
@@ -11,4 +13,6 @@ public interface UserService {
     UserResponseDTO getUserProfile(String email);
 
     UserResponseDTO updateUserProfile(String email, UpdateProfileRequestDTO updateProfileRequestDTO);
+
+    UserResponseDTO changeUserRole(String adminEmail, UUID targetId, ChangeRoleRequestDTO changeRoleRequestDTO);
 }

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserServiceImpl.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/service/UserServiceImpl.java
@@ -10,8 +10,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 /**
- * SY-2 | SY-3 | SY-6 Implementación de UserService
+ * SY-2 | SY-3 | SY-6 | SY-7 | SY-8 Implementación de UserService
  */
 @Service
 @RequiredArgsConstructor
@@ -91,6 +93,25 @@ public class UserServiceImpl implements UserService{
         userMapper.updateEntityFromDTO(updateProfileRequestDTO, user);
 
         return userMapper.toResponseDTO(user);
+    }
+
+    @Override
+    @Transactional
+    public UserResponseDTO changeUserRole(String adminEmail, UUID targetId, ChangeRoleRequestDTO changeRoleRequestDTO){
+
+        User admin = userRepository.findUserByEmail(adminEmail)
+                .orElseThrow(() -> new UserNotFoundException(adminEmail));
+
+        if(admin.getId().equals(targetId)){
+            throw new SelfRoleChangeException();
+        }
+
+        User target = userRepository.findById(targetId)
+                .orElseThrow(() -> new UserNotFoundException(targetId.toString()));
+
+        target.setRole(Role.valueOf(changeRoleRequestDTO.getRole()));
+
+        return userMapper.toResponseDTO(userRepository.save(target));
     }
 
 }


### PR DESCRIPTION
# SY-8 Roles (dueño - voluntario - administrador)

## ¿Qué hace este cambio?
Implementa el sistema de gestión y asignación de roles para la plataforma. Este cambio permite que los usuarios con privilegios de Administrador modifiquen el rol de otros usuarios (Dueño, Voluntario o Administrador) a través de un nuevo endpoint seguro, asegurando la integridad del sistema mediante validaciones de negocio y un manejo de errores centralizado.

## Cambios principales
### Gestión de Roles y Seguridad
**Nuevo Endpoint Administrativo**: Se agregó `PATCH /api/users/{id}/role` protegido con `@PreAuthorize("hasRole('ADMIN')")`, permitiendo la escalada o modificación de permisos.

**Lógica de Negocio en Service**: Implementación en `UserServiceImpl` que valida restricciones críticas, como la prohibición de que un administrador modifique su propio rol (autobloqueo).

**DTO de Transferencia**: Creación de `ChangeRoleRequestDTO` para una validación estricta del payload de entrada.

###  Robustez y Manejo de Errores
**Excepciones Personalizadas**: Introducción de `SelfRoleChangeException` para capturar intentos de modificación de rol propia.

**Global Exception Handler**: Se mejoró la captura de `AccessDeniedException` (403 Forbidden) y se optimizaron los manejadores existentes para devolver respuestas consistentes al frontend.

###  Herramientas de Desarrollo
**Initial Data Seed**: Se implementó `DataInitializerConfig` para generar automáticamente un usuario administrador al arrancar la aplicación en entornos de desarrollo.

**Patrón Builder**: Se habilitó `@Builder` de **Lombok** en el modelo `User` para facilitar la creación de instancias y mejorar la legibilidad de las pruebas unitarias.