### PR TITLE
SY-40 Autenticación por API Key para Integraciones Externas

### DIFF
--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/config/JpaAuditingConfig.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/config/JpaAuditingConfig.java
@@ -1,0 +1,13 @@
+package com.javadiseno.sanosysalvos.integration.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/**
+ * SY-40 Activa @CreatedDate en entidades
+ */
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/config/SecurityConfig.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.javadiseno.sanosysalvos.integration.config;
+
+import com.javadiseno.sanosysalvos.integration.security.ApiKeyAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final ApiKeyAuthenticationFilter apiKeyAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .anyRequest().permitAll()
+                )
+
+                // TEMPORAL: Remover en producción (H2 Console necesita frames del mismo origen)
+                .headers(headers ->
+                        headers.frameOptions(frame -> frame.sameOrigin()))
+
+                .addFilterBefore(apiKeyAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/model/InstitutionApiKey.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/model/InstitutionApiKey.java
@@ -1,0 +1,52 @@
+package com.javadiseno.sanosysalvos.integration.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// SY-40 Modelo que representa la credencial de acceso para organismos externos
+
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+@Table(
+    name = "institution_api_keys",
+    uniqueConstraints = {
+            @UniqueConstraint(name = "uk_institution_api_key", columnNames = "api_key"),
+            @UniqueConstraint(name = "uk_institution_user_id", columnNames = "user_id")
+    }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InstitutionApiKey {
+
+    @Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @PrePersist
+    private void prePersist(){
+        if(this.id == null){
+            this.id = UUID.randomUUID();
+        }
+    }
+
+    @Column(name = "institution_name", nullable = false, length = 125)
+    private String institutionName;
+
+    @Column(name = "api_key", nullable = false, length = 250)
+    private String apiKey;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/repository/InstitutionApiKeyRepository.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/repository/InstitutionApiKeyRepository.java
@@ -1,0 +1,13 @@
+package com.javadiseno.sanosysalvos.integration.repository;
+
+import com.javadiseno.sanosysalvos.integration.model.InstitutionApiKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface InstitutionApiKeyRepository extends JpaRepository<InstitutionApiKey, UUID> {
+    Optional<InstitutionApiKey> findByApiKey(String apiKey);
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/security/ApiKeyAuthenticationFilter.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/security/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.javadiseno.sanosysalvos.integration.security;
+
+import com.javadiseno.sanosysalvos.integration.model.InstitutionApiKey;
+import com.javadiseno.sanosysalvos.integration.repository.InstitutionApiKeyRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * SY-40 Filtro que valida la API key en cada request a api/v1/integration
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String INSTITUTION_ATTRIBUTE = "authenticatedInstitution";
+    public static final String API_KEY_HEADER = "X-Api-Key";
+    private final InstitutionApiKeyRepository institutionApiKeyRepository;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+        if(!request.getRequestURI().startsWith("api/v1/integration")){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String apiKey = request.getHeader(API_KEY_HEADER);
+
+        if (apiKey == null || apiKey.isBlank()) {
+            log.warn("Request a {} sin header {}", request.getRequestURI(), API_KEY_HEADER);
+            writeUnauthorized(response, "Header X-Api-Key es requerido");
+            return;
+        }
+
+        InstitutionApiKey institutionApiKey = institutionApiKeyRepository
+                .findByApiKey(apiKey)
+                .orElse(null);
+
+        if (institutionApiKey == null){
+            log.warn("API key inválida: {}...", apiKey.substring(0, Math.min(6, apiKey.length())));
+            writeUnauthorized(response, "API key inválida");
+            return;
+        }
+
+        log.info("Institución autenticada: {}", institutionApiKey.getInstitutionName());
+        request.setAttribute(INSTITUTION_ATTRIBUTE, institutionApiKey);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void writeUnauthorized(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json; charset=UTF-8");
+        response.getWriter().write(
+                "{\"status\":401,\"message\":\"" + message + "\"}"
+        );
+    }
+
+}

--- a/msvc-integration/src/main/resources/application-dev.properties
+++ b/msvc-integration/src/main/resources/application-dev.properties
@@ -3,14 +3,14 @@
 # CUANDO SE IMPLEMENTE LA SUBRED PRIVADA CON RDS POSTGRESQL EN AWS SE USARA POSTGREQL.
 
 # Especifica la ubicación exacta de la BD (H2, en memoria ram de la pc)
-spring.datasource.url=jdbc:h2:mem:sanosdb
+spring.datasource.url=jdbc:h2:mem:sanosdb;INIT=CREATE SCHEMA IF NOT EXISTS integration_schema
 # Schema
 spring.jpa.properties.hibernate.default_schema=integration_schema
 # Que Driver usar para hablar con H2
 spring.datasource.driverClassName=org.h2.Driver
 # Define las credenciales para autenticarse en la BD.
-spring.datasource.username=admin
-spring.datasource.password=sanos123
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 
 # Le dice a Hibernate que hable el "Dialecto" de H2
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/User.java
+++ b/msvc-user/src/main/java/com/javadiseno/sanosysalvos/user/model/User.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 public class User {
 
     @Id
+    @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
     @PrePersist


### PR DESCRIPTION
### ¿Qué hace este cambio?

Implementa el sistema de autenticación y seguridad para el módulo `msvc-integration`. Este cambio permite que instituciones externas accedan a los endpoints de integración mediante un API Key validado por un filtro de seguridad dedicado, asegurando la integridad del sistema mediante la verificación de credenciales almacenadas en base de datos, gestión de auditoría automática y un manejo de configuración basado en variables de entorno.

### Cambios principales

#### Autenticación por API Key y Seguridad

- **Nuevo Filtro de Seguridad:** Se agregó `ApiKeyAuthenticationFilter` que valida el header `X-Api-Key` en todas las solicitudes a `api/v1/integration`, permitiendo el acceso únicamente a instituciones autorizadas. El filtro verifica la clave contra las credenciales almacenadas y adjunta la institución autenticada al contexto de la solicitud.
- **Configuración de Spring Security:** Se introdujo `SecurityConfig` para registrar el filtro de API Key en la cadena de seguridad, configurar la gestión de sesiones sin estado (stateless) y permitir temporalmente el acceso a la consola H2 en entornos de desarrollo.

#### Modelo de Datos y Persistencia

- **Nueva Entidad JPA:** Se creó `InstitutionApiKey` para representar las credenciales de instituciones externas, incluyendo campos para nombre de institución, API key, ID de usuario y timestamp de creación, con auditoría automática mediante `@CreatedDate`.
- **Nuevo Repositorio:** Se añadió `InstitutionApiKeyRepository` para la gestión de entidades `InstitutionApiKey` y la consulta por API key.
- **Auditoría JPA:** Se habilitó mediante una clase de configuración dedicada, permitiendo el manejo automático de campos auditados como `@CreatedDate`.

#### Cambios de Configuración

- **Variables de Entorno:** Se actualizó `application-dev.properties` para gestionar las credenciales de base de datos mediante variables de entorno, mejorando la seguridad del sistema.
- **Inicialización del Schema:** Se configuró la inicialización del schema H2 solo si no existe, evitando conflictos en reinicios del entorno de desarrollo.

#### Corrección Menor

- Se agregó el mapeo explícito de columna para el campo `id` en la entidad `User`, asegurando un comportamiento correcto en la persistencia.