### PR TITLE
SY-41 feat(integration): validación externa

### DIFF
--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportMapper.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportMapper.java
@@ -1,0 +1,28 @@
+package com.javadiseno.sanosysalvos.integration.dto;
+
+import org.mapstruct.*;
+
+import java.math.BigDecimal;
+
+/**
+ * SY-41 Transforma el payload externo al formato interno de Report Service
+ */
+@Mapper(componentModel = "spring")
+public interface ExternalReportMapper {
+
+    @Mapping(source = "reportType", target = "tipo")
+    @Mapping(source = "title", target = "titulo")
+    @Mapping(source = "description", target = "descripcion")
+    @Mapping(source = "latitude", target = "latitud")
+    @Mapping(source = "longitude", target = "longitud")
+    @Mapping(source = "locationText", target = "ubicacionTexto")
+    @Mapping(source = "eventDate", target = "fechaReporte")
+    @Mapping(source = "petId", target = "petId")
+    @Mapping(target = "reporterUserId", ignore = true)
+    InternalCreateReportDTO toInternal(ExternalReportRequestDTO externalReportRequestDTO);
+
+    // Convertor de double a BigDecimal. MapStruct lo usa automáticamente en longitud y latitud
+    default BigDecimal doubleToBigDecimal(Double value) {
+        return value == null ? null : BigDecimal.valueOf(value);
+    }
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportRequestDTO.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportRequestDTO.java
@@ -1,0 +1,59 @@
+package com.javadiseno.sanosysalvos.integration.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ExternalReportRequestDTO {
+
+    @NotBlank(message = "El ID externo del reporte es obligatorio")
+    @Size(max = 100, message = "El ID externo no puede superar los 100 caracteres")
+    private String externalReportId;
+
+    @NotBlank(message = "El tipo de reporte es obligatorio")
+    @Pattern(
+            regexp = "LOST|FOUND",
+            message = "El tipo debe ser LOST o FOUND"
+    )
+    private String reportType;
+
+    @NotNull(message = "El petId es obligatorio")
+    private UUID petId;
+
+    @NotBlank(message = "La especie es obligatoria")
+    @Size(max = 50, message = "La especie no puede superar los 50 caracteres")
+    private String species;
+
+    @Size(max = 50, message = "La raza no puede superar los 50 caracteres")
+    private String breed;
+
+    @Size(max = 50, message = "El color no puede superar los 50 caracteres")
+    private String color;
+
+    @Size(max = 100, message = "El título no puede superar los 100 caracteres")
+    private String title;
+
+    @Size(max = 600, message = "La descripción no puede superar los 600 caracteres")
+    private String description;
+
+    @NotNull(message = "La latitud es obligatoria")
+    @DecimalMin(value = "-90.0", message = "Latidud mínima: -90")
+    @DecimalMax(value = "90.0", message = "Latidud máxima: 90")
+    private Double latitude;
+
+    @NotNull(message = "La longitud es obligatoria")
+    @DecimalMin(value = "-180.0", message = "Latidud mínima: -180")
+    @DecimalMax(value = "180.0", message = "Latidud máxima: 180")
+    private Double longitude;
+
+    @Size(max = 2000, message = "La descripción de la locación no puede superar los 2000 caracteres")
+    private String locationText;
+
+    private LocalDateTime eventDate;
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/InternalCreateReportDTO.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/InternalCreateReportDTO.java
@@ -1,0 +1,22 @@
+package com.javadiseno.sanosysalvos.integration.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InternalCreateReportDTO {
+    private String tipo;
+    private String titulo;
+    private String descripcion;
+    private BigDecimal latitud;
+    private BigDecimal longitud;
+    private Instant fechaReporte;
+    private UUID petId;
+    private UUID reporterUserId;
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/exception/GlobalExceptionHandler.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/exception/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.javadiseno.sanosysalvos.integration.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+// SY-41 Manejo centralizado de excepciones de Integration Service
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ValidationErrorResponse> handleValidation(MethodArgumentNotValidException ex){
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String field = ((FieldError) error).getField();
+            errors.put(field, error.getDefaultMessage());
+        });
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ValidationErrorResponse(
+                        HttpStatus.BAD_REQUEST.value(),
+                        "Error de validación en los datos enviados",
+                        errors,
+                        LocalDateTime.now()
+                ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneral(Exception ex){
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(
+                        HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        "Error interno del Servidor",
+                        LocalDateTime.now()
+                ));
+    }
+
+    public record ErrorResponse(int status, String message, LocalDateTime timestamp){}
+
+    public record ValidationErrorResponse(int status, String message, Map<String, String> errors, LocalDateTime timestamp){}
+}


### PR DESCRIPTION
## SY-41 Validación y Mapeo de Datos Externos para Integración de Reportes

### ¿Qué hace este cambio?

Implementa la capa de validación y transformación de datos externos para el módulo de integración. Este cambio permite recibir reportes desde instituciones externas, validar su estructura mediante anotaciones de constraint, y transformarlos al formato interno del servicio a través de un mapper dedicado, garantizando la integridad de los datos y un manejo de errores centralizado y consistente.

### Cambios principales

#### DTOs para Integración de Reportes Externos

- **Nuevo DTO Externo:** Se creó `ExternalReportRequestDTO` para representar el payload entrante de reportes externos, incluyendo anotaciones de validación en todos sus campos.
- **Nuevo DTO Interno:** Se creó `InternalCreateReportDTO` para representar el formato interno del reporte utilizado por el servicio.

#### Lógica de Mapeo

- **Nuevo Mapper:** Se introdujo `ExternalReportMapper` usando MapStruct para convertir de `ExternalReportRequestDTO` a `InternalCreateReportDTO`, incluyendo mapeos personalizados para nombres de campos y conversiones de tipos.

#### Manejo Centralizado de Errores

- **Global Exception Handler:** Se agregó `GlobalExceptionHandler` para capturar errores de validación (`MethodArgumentNotValidException`) y excepciones generales, retornando respuestas de error estructuradas y consistentes al frontend.