### PR TITLE
SY-42 feat(integration): implementar la integración del servicio de reportes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 
 # Requiere archivo ".env" (copiar desde ".env.example"). No commitees secretos.
-# Puertos HOST: 9081/9082/9083. Red interna: servicios en 8081/8082/8083.
+# Puertos HOST: 9081/9082/9083/9085. Red interna: servicios en 8081/8082/8083/8085.
 services:
   postgres:
     image: postgres:16-alpine
@@ -96,6 +96,28 @@ services:
         condition: service_started
     ports:
       - "9082:8082"
+
+  msvc-integration:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.msvc-integration
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      DB_HOST: postgres
+      DB_PORT: 5432
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXPIRATION_MS: ${JWT_EXPIRATION_MS:-86400000}
+      SANOS_REPORT_SERVICE_URL: http://msvc-report:8082
+    depends_on:
+      postgres:
+        condition: service_healthy
+      msvc-report:
+        condition: service_started
+    ports:
+      - "9085:8085"
 
 volumes:
   minio_data: {}

--- a/docker/Dockerfile.msvc-integration
+++ b/docker/Dockerfile.msvc-integration
@@ -1,0 +1,10 @@
+FROM maven:3.9-eclipse-temurin-21-alpine AS build
+WORKDIR /w
+COPY . .
+RUN mvn -q -pl msvc-integration -am package -DskipTests
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /w/msvc-integration/target/msvc-integration-*.jar app.jar
+EXPOSE 8085
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/docker/init-db.sql
+++ b/docker/init-db.sql
@@ -1,3 +1,4 @@
 -- Esquemas para User y Pet; Report usa public
 CREATE SCHEMA IF NOT EXISTS users_schema;
 CREATE SCHEMA IF NOT EXISTS pets_schema;
+CREATE SCHEMA IF NOT EXISTS integrations_schema;

--- a/msvc-integration/pom.xml
+++ b/msvc-integration/pom.xml
@@ -40,15 +40,13 @@
 		</dependency>
 
 		<!-- Persistencia -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 
-<!-- ⚠️ DEPENDENCIA DE POSTGRESQL PARA FUTURO -->
-<!--		<dependency>-->
-<!--			<groupId>org.postgresql</groupId>-->
-<!--			<artifactId>postgresql</artifactId>-->
-<!--			<scope>runtime</scope>-->
-<!--		</dependency>-->
-
-<!-- ⚠️ H2 TEMPORAL PARA PRUEBAS -->
+		<!-- H2 temporal para desarrollo local -->
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/msvc-integration/pom.xml
+++ b/msvc-integration/pom.xml
@@ -108,6 +108,25 @@
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>eventbridge</artifactId>
 		</dependency>
+
+		<!-- JWT: Necesario para la generación de tokens y validación -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -140,6 +159,16 @@
 									<groupId>org.projectlombok</groupId>
 									<artifactId>lombok</artifactId>
 								</path>
+								<path>
+									<groupId>org.projectlombok</groupId>
+									<artifactId>lombok-mapstruct-binding</artifactId>
+									<version>0.2.0</version>
+								</path>
+								<path>
+									<groupId>org.mapstruct</groupId>
+									<artifactId>mapstruct-processor</artifactId>
+									<version>${mapstruct.version}</version>
+								</path>
 							</annotationProcessorPaths>
 						</configuration>
 					</execution>
@@ -154,6 +183,16 @@
 								<path>
 									<groupId>org.projectlombok</groupId>
 									<artifactId>lombok</artifactId>
+								</path>
+								<path>
+									<groupId>org.projectlombok</groupId>
+									<artifactId>lombok-mapstruct-binding</artifactId>
+									<version>0.2.0</version>
+								</path>
+								<path>
+									<groupId>org.mapstruct</groupId>
+									<artifactId>mapstruct-processor</artifactId>
+									<version>${mapstruct.version}</version>
 								</path>
 							</annotationProcessorPaths>
 						</configuration>

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/client/ReportServiceClient.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/client/ReportServiceClient.java
@@ -1,0 +1,17 @@
+package com.javadiseno.sanosysalvos.integration.client;
+
+import com.javadiseno.sanosysalvos.integration.dto.InternalCreateReportDTO;
+import com.javadiseno.sanosysalvos.integration.dto.ReportSummaryResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+        name = "report-service",
+        url = "${sanos.report-service.url:http://localhost:8082}"
+)
+public interface ReportServiceClient {
+
+    @PostMapping("/api/v1/reports")
+    ReportSummaryResponse createReport(@RequestBody InternalCreateReportDTO body);
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/client/ReportServiceFeignInterceptor.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/client/ReportServiceFeignInterceptor.java
@@ -1,0 +1,65 @@
+package com.javadiseno.sanosysalvos.integration.client;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class ReportServiceFeignInterceptor implements RequestInterceptor {
+    private static final ThreadLocal<UUID> CURRENT_USER_ID = new ThreadLocal<>();
+
+    private final SecretKey secretKey;
+    private final Long expirationMs;
+
+    public ReportServiceFeignInterceptor(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.expiration-ms}") Long expirationMs
+    ){
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    public static void setCurrentUserId(UUID userId) {
+        CURRENT_USER_ID.set(userId);
+    }
+
+    public static void clearCurrentUserId() {
+        CURRENT_USER_ID.remove();
+    }
+
+    @Override
+    public void apply(RequestTemplate template) {
+        UUID userId = CURRENT_USER_ID.get();
+
+        if (userId == null) {
+            log.warn("ReportServiceFeignInterceptor: no hay userId en ThreadLocal");
+            return;
+        }
+
+        String token = generateToken(userId);
+        template.header("Authorization", "Bearer " + token);
+    }
+
+    private String generateToken(UUID userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("role", "INSTITUTION")
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/config/FeignConfig.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/config/FeignConfig.java
@@ -1,0 +1,9 @@
+package com.javadiseno.sanosysalvos.integration.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.javadiseno.sanosysalvos.integration.client")
+public class FeignConfig {
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/controller/IntegrationController.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/controller/IntegrationController.java
@@ -1,0 +1,39 @@
+package com.javadiseno.sanosysalvos.integration.controller;
+
+import com.javadiseno.sanosysalvos.integration.dto.ExternalReportRequestDTO;
+import com.javadiseno.sanosysalvos.integration.dto.ExternalReportResponseDTO;
+import com.javadiseno.sanosysalvos.integration.model.InstitutionApiKey;
+import com.javadiseno.sanosysalvos.integration.security.ApiKeyAuthenticationFilter;
+import com.javadiseno.sanosysalvos.integration.service.IntegrationService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/integration")
+@RequiredArgsConstructor
+public class IntegrationController {
+    private final IntegrationService integrationService;
+
+        @PostMapping("/reports")
+    public ResponseEntity<ExternalReportResponseDTO> receiveReport(
+            @Valid @RequestBody ExternalReportRequestDTO externalReportRequestDTO,
+            HttpServletRequest request
+    ){
+        InstitutionApiKey institution = (InstitutionApiKey)
+                request.getAttribute(ApiKeyAuthenticationFilter.INSTITUTION_ATTRIBUTE);
+
+        ExternalReportResponseDTO response = integrationService
+                .processExternalReport(institution, externalReportRequestDTO);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportMapper.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportMapper.java
@@ -3,6 +3,9 @@ package com.javadiseno.sanosysalvos.integration.dto;
 import org.mapstruct.*;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 /**
  * SY-41 Transforma el payload externo al formato interno de Report Service
@@ -24,5 +27,10 @@ public interface ExternalReportMapper {
     // Convertor de double a BigDecimal. MapStruct lo usa automáticamente en longitud y latitud
     default BigDecimal doubleToBigDecimal(Double value) {
         return value == null ? null : BigDecimal.valueOf(value);
+    }
+
+    // Convierte fecha local del payload externo al formato Instant que usa Report Service
+    default Instant localDateTimeToInstant(LocalDateTime value) {
+        return value == null ? null : value.toInstant(ZoneOffset.UTC);
     }
 }

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportRequestDTO.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportRequestDTO.java
@@ -26,16 +26,6 @@ public class ExternalReportRequestDTO {
     @NotNull(message = "El petId es obligatorio")
     private UUID petId;
 
-    @NotBlank(message = "La especie es obligatoria")
-    @Size(max = 50, message = "La especie no puede superar los 50 caracteres")
-    private String species;
-
-    @Size(max = 50, message = "La raza no puede superar los 50 caracteres")
-    private String breed;
-
-    @Size(max = 50, message = "El color no puede superar los 50 caracteres")
-    private String color;
-
     @Size(max = 100, message = "El título no puede superar los 100 caracteres")
     private String title;
 

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportResponseDTO.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ExternalReportResponseDTO.java
@@ -1,0 +1,18 @@
+package com.javadiseno.sanosysalvos.integration.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExternalReportResponseDTO {
+    private String externalReportId;
+    private UUID internalReportId;
+    private String message;
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/InternalCreateReportDTO.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/InternalCreateReportDTO.java
@@ -16,6 +16,7 @@ public class InternalCreateReportDTO {
     private String descripcion;
     private BigDecimal latitud;
     private BigDecimal longitud;
+    private String ubicacionTexto;
     private Instant fechaReporte;
     private UUID petId;
     private UUID reporterUserId;

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ReportSummaryResponse.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/dto/ReportSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.javadiseno.sanosysalvos.integration.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ReportSummaryResponse {
+    private UUID id;
+    private String type;
+    private String title;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private Instant reportedAt;
+    private UUID petId;
+    private UUID reporterUserId;
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/exception/GlobalExceptionHandler.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/exception/GlobalExceptionHandler.java
@@ -42,6 +42,17 @@ public class GlobalExceptionHandler {
                 ));
     }
 
+    @ExceptionHandler(ReportServiceException.class)
+    public ResponseEntity<ErrorResponse> handleReportServiceError(ReportServiceException exception){
+        return ResponseEntity
+                .status(HttpStatus.BAD_GATEWAY)
+                .body(new ErrorResponse(
+                        HttpStatus.BAD_GATEWAY.value(),
+                        exception.getMessage(),
+                        LocalDateTime.now()
+                ));
+    }
+
     public record ErrorResponse(int status, String message, LocalDateTime timestamp){}
 
     public record ValidationErrorResponse(int status, String message, Map<String, String> errors, LocalDateTime timestamp){}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/exception/ReportServiceException.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/exception/ReportServiceException.java
@@ -1,0 +1,14 @@
+package com.javadiseno.sanosysalvos.integration.exception;
+
+public class ReportServiceException extends RuntimeException {
+  private final int upstreamStatus;
+
+  public ReportServiceException(int upstreamStatus, String body) {
+        super("Error al llamar a Report Service [" + upstreamStatus + "]: " + body);
+        this.upstreamStatus = upstreamStatus;
+    }
+
+    public int getUpstreamStatus() {
+      return upstreamStatus;
+    }
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/model/InstitutionApiKey.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/model/InstitutionApiKey.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 @Entity
 @Table(
     name = "institution_api_keys",
+    schema = "integrations_schema",
     uniqueConstraints = {
             @UniqueConstraint(name = "uk_institution_api_key", columnNames = "api_key"),
             @UniqueConstraint(name = "uk_institution_user_id", columnNames = "user_id")

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/security/ApiKeyAuthenticationFilter.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/security/ApiKeyAuthenticationFilter.java
@@ -32,7 +32,7 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
             @NonNull HttpServletRequest request,
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain) throws ServletException, IOException {
-        if(!request.getRequestURI().startsWith("api/v1/integration")){
+        if(!request.getRequestURI().startsWith("/api/v1/integration")){
             filterChain.doFilter(request, response);
             return;
         }

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/service/IntegrationService.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/service/IntegrationService.java
@@ -1,0 +1,13 @@
+package com.javadiseno.sanosysalvos.integration.service;
+
+import com.javadiseno.sanosysalvos.integration.dto.ExternalReportRequestDTO;
+import com.javadiseno.sanosysalvos.integration.dto.ExternalReportResponseDTO;
+import com.javadiseno.sanosysalvos.integration.model.InstitutionApiKey;
+
+public interface IntegrationService {
+
+    ExternalReportResponseDTO processExternalReport(
+            InstitutionApiKey institution,
+            ExternalReportRequestDTO externalReportRequestDTO
+    );
+}

--- a/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/service/IntegrationServiceImpl.java
+++ b/msvc-integration/src/main/java/com/javadiseno/sanosysalvos/integration/service/IntegrationServiceImpl.java
@@ -1,0 +1,53 @@
+package com.javadiseno.sanosysalvos.integration.service;
+
+import com.javadiseno.sanosysalvos.integration.client.ReportServiceClient;
+import com.javadiseno.sanosysalvos.integration.client.ReportServiceFeignInterceptor;
+import com.javadiseno.sanosysalvos.integration.dto.*;
+import com.javadiseno.sanosysalvos.integration.exception.ReportServiceException;
+import com.javadiseno.sanosysalvos.integration.model.InstitutionApiKey;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class IntegrationServiceImpl implements IntegrationService{
+
+    private final ExternalReportMapper externalReportMapper;
+    private final ReportServiceClient reportServiceClient;
+
+    @Override
+    public ExternalReportResponseDTO processExternalReport(
+            InstitutionApiKey institution,
+            ExternalReportRequestDTO externalReportRequestDTO
+    ){
+        InternalCreateReportDTO internalDto = externalReportMapper.toInternal(externalReportRequestDTO);
+        internalDto.setReporterUserId(institution.getUserId());
+
+        ReportSummaryResponse reportResponse;
+        try{
+
+            ReportServiceFeignInterceptor.setCurrentUserId(institution.getUserId());
+            reportResponse = reportServiceClient.createReport(internalDto);
+
+        } catch (FeignException exception){
+
+            log.error("Error llamando a Report service: status={} body={}", exception.status(), exception.contentUTF8());
+            throw new ReportServiceException(exception.status(), exception.contentUTF8());
+
+        } finally {
+            ReportServiceFeignInterceptor.clearCurrentUserId();
+        }
+
+        log.info("Reporte creado\nInstitución: {} externalId: {} internalId: {}",
+                institution.getInstitutionName(), externalReportRequestDTO.getExternalReportId(), reportResponse.getId());
+
+        return ExternalReportResponseDTO.builder()
+                .externalReportId(externalReportRequestDTO.getExternalReportId())
+                .internalReportId(reportResponse.getId())
+                .message("Reporte Creado exitosamente")
+                .build();
+    }
+}

--- a/msvc-integration/src/main/resources/application-dev.properties
+++ b/msvc-integration/src/main/resources/application-dev.properties
@@ -2,24 +2,30 @@
 # ADVERTENCIA: ESTA BASE DE DATOS H2 SERA TEMPORAL PARA HACER PRUEBAS RAPIDAS.
 # CUANDO SE IMPLEMENTE LA SUBRED PRIVADA CON RDS POSTGRESQL EN AWS SE USARA POSTGREQL.
 
-# Especifica la ubicación exacta de la BD (H2, en memoria ram de la pc)
-spring.datasource.url=jdbc:h2:mem:sanosdb;INIT=CREATE SCHEMA IF NOT EXISTS integration_schema
+# Especifica la ubicacion exacta de la BD (H2, en memoria RAM local)
+spring.datasource.url=jdbc:h2:mem:sanosdb;INIT=CREATE SCHEMA IF NOT EXISTS integrations_schema
 # Schema
-spring.jpa.properties.hibernate.default_schema=integration_schema
+spring.jpa.properties.hibernate.default_schema=integrations_schema
 # Que Driver usar para hablar con H2
 spring.datasource.driverClassName=org.h2.Driver
 # Define las credenciales para autenticarse en la BD.
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 
-# Le dice a Hibernate que hable el "Dialecto" de H2
+# Le dice a Hibernate que hable el "dialecto" de H2
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 # Crea o actualiza las Tablas de la BD al arrancar la App
 spring.jpa.hibernate.ddl-auto=update
-# Mostrar consultas SQL que la aplicación ejecuta
+# Mostrar consultas SQL que la aplicacion ejecuta
 spring.jpa.show-sql=true
 
 # Activar interfaz web para ver las tablas y hacer consultas SQL desde el navegador.
 spring.h2.console.enabled=true
-# Dirección de la interfaz.
+# Direccion de la interfaz.
 spring.h2.console.path=/h2-console
+
+jwt.secret=${JWT_SECRET}
+jwt.expiration-ms=${JWT_EXPIRATION_MS:86400000}
+
+# URL del servicio de reportes
+sanos.report-service.url=${SANOS_REPORT_SERVICE_URL:http://localhost:8082}

--- a/msvc-integration/src/main/resources/application-docker.properties
+++ b/msvc-integration/src/main/resources/application-docker.properties
@@ -1,0 +1,15 @@
+# PostgreSQL (docker-compose). Variables desde .env / entorno.
+jwt.secret=${JWT_SECRET}
+jwt.expiration-ms=${JWT_EXPIRATION_MS:86400000}
+
+spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${POSTGRES_DB}
+spring.datasource.username=${POSTGRES_USER}
+spring.datasource.password=${POSTGRES_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+spring.h2.console.enabled=false
+
+# URL del servicio de reportes
+sanos.report-service.url=${SANOS_REPORT_SERVICE_URL:http://msvc-report:8082}


### PR DESCRIPTION
## SY-42 Flujo de Integración para Envío de Reportes Externos al Servicio Interno

### ¿Qué hace este cambio?

Implementa el flujo completo de integración que permite a instituciones externas enviar reportes a través de la API, los cuales son redirigidos de forma segura al servicio interno de reportes. Este cambio incorpora comunicación mediante Feign con autenticación JWT, transformación de datos entre formatos externo e interno, manejo de errores robusto y la configuración necesaria para soportar el flujo end-to-end.

### Cambios principales

#### Integración con el Servicio de Reportes

- **Nuevo Feign Client:** Se agregó `ReportServiceClient` para realizar llamadas HTTP al servicio interno de reportes.
- **Nuevo Feign Interceptor:** Se introdujo `ReportServiceFeignInterceptor` para generar y adjuntar tokens JWT en cada solicitud saliente, asegurando la comunicación entre servicios.

#### DTOs y Mapeo

- **Nuevos DTOs:** Se añadieron `ExternalReportRequestDTO`, `ExternalReportResponseDTO`, `InternalCreateReportDTO` y `ReportSummaryResponse` para gestionar la transferencia de datos entre el cliente externo y el servicio de reportes.
- **Mappers Actualizados:** Se extendieron los mappers existentes para cubrir la conversión entre formatos y el manejo de conversiones de fecha/hora.
- **Limpieza de Campos:** Se eliminaron los campos no utilizados `species`, `breed` y `color` de `ExternalReportRequestDTO` para alinearlo con los requerimientos actuales.

#### Manejo de Errores

- **Excepción Personalizada:** Se creó `ReportServiceException` para capturar fallos en las llamadas al servicio interno de reportes.
- **Global Exception Handler Extendido:** Se amplió el manejador global para retornar respuestas de error estructuradas cuando falla la comunicación con el servicio de reportes.

#### Configuración y Dependencias

- **Actualización de `pom.xml`:** Se agregaron las dependencias de JWT y MapStruct, y se configuraron los annotation processors para Lombok y MapStruct.
- **Nuevas Properties:** Se añadieron propiedades de aplicación para la URL del servicio de reportes y la configuración JWT.

#### Controlador y Seguridad

- **Nuevo Controlador:** Se agregó `IntegrationController` exponiendo el endpoint `POST /api/v1/integration/reports`, protegido por autenticación de API key.
- **Corrección de Bug:** Se corrigió el filtro de API key para que coincida correctamente con la ruta del endpoint.