### PR TITLE
SY-70 feature(analytics): crear DTOs para el consumo de eventos

### DIFF
--- a/msvc-analytics/src/main/java/com/javadiseno/sanosysalvos/analytics/dtos/BusEventDTO.java
+++ b/msvc-analytics/src/main/java/com/javadiseno/sanosysalvos/analytics/dtos/BusEventDTO.java
@@ -1,0 +1,44 @@
+package com.javadiseno.sanosysalvos.analytics.dtos;
+
+import com.fasterxml.jackson.annotation.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// SY-70 Esquema del evento que llega desde EventBridge
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+// Consumir campos nuevos sin romper el servicio
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BusEventDTO {
+
+    private String source;
+
+    @JsonProperty("detail-type")
+    private String detailType;
+
+    private String detail;
+
+    public static class EventDetailDTO{
+
+        private UUID reportId;
+
+        private UUID petId;
+
+        private UUID userId;
+
+        private Double latitude;
+
+        private Double longitude;
+
+        private Instant eventDate;
+
+        private Double matchScore;
+
+        private UUID matchedReportId;
+    }
+}

--- a/msvc-analytics/src/main/java/com/javadiseno/sanosysalvos/analytics/dtos/EventType.java
+++ b/msvc-analytics/src/main/java/com/javadiseno/sanosysalvos/analytics/dtos/EventType.java
@@ -1,0 +1,10 @@
+package com.javadiseno.sanosysalvos.analytics.dtos;
+
+// SY-70 Tipos de eventos del bus que Analytics consume
+
+public enum EventType {
+    pet_reported,
+    pet_found,
+    match_found,
+    pet_recovered
+}


### PR DESCRIPTION
## SY-70 Schema de Eventos y DTOs para el Servicio de Analíticas 

### ¿Qué hace este cambio?

Implementa los objetos de transferencia de datos y enumeraciones necesarios para el manejo de eventos en el servicio de analíticas. Este cambio define el schema para los eventos recibidos desde EventBridge y enumera los tipos de eventos que el servicio de analíticas puede consumir, asegurando compatibilidad futura mediante el soporte de campos desconocidos.

---

### Cambios principales

#### DTOs y Schema de Eventos

- **Nuevo DTO de Evento:** Se creó `BusEventDTO` para definir el schema de los eventos recibidos desde EventBridge, incluyendo soporte para campos desconocidos que garantiza compatibilidad futura. Contiene la clase interna `EventDetailDTO` para representar información detallada del evento como IDs, coordenadas y fechas.

#### Enumeración de Tipos de Evento

- **Nuevo Enum `EventType`:** Se introdujo para enumerar los tipos de eventos que el servicio de analíticas puede procesar: `pet_reported`, `pet_found`, `match_found` y `pet_recovered`.